### PR TITLE
feat: add persona onboarding and equipment confidence tiers

### DIFF
--- a/data/amps/Denon_X3800H.json
+++ b/data/amps/Denon_X3800H.json
@@ -1,0 +1,6 @@
+{
+  "brand": "Denon",
+  "model": "X3800H",
+  "type": "avr",
+  "power_w_8ohm_all": 105
+}

--- a/data/amps/Emotiva_BasX_A3.json
+++ b/data/amps/Emotiva_BasX_A3.json
@@ -1,0 +1,6 @@
+{
+  "brand": "Emotiva",
+  "model": "BasX A3",
+  "type": "amp",
+  "power_w_8ohm_all": 140
+}

--- a/data/manifest.json
+++ b/data/manifest.json
@@ -1,0 +1,4 @@
+{
+  "speakers": ["JBL_Studio_590.json","KEF_Q350.json","Revel_F206.json"],
+  "amps": ["Denon_X3800H.json","Emotiva_BasX_A3.json"]
+}

--- a/data/speakers/JBL_Studio_590.json
+++ b/data/speakers/JBL_Studio_590.json
@@ -1,0 +1,26 @@
+{
+  "brand": "JBL",
+  "model": "Studio 590",
+  "type": "floorstanding",
+  "notes": "User-owned; spinorama TBD. Using horn + 8in woofer hints.",
+  "sensitivity_db": 92.0,
+  "impedance_ohm_nom": 6,
+  "impedance_ohm_min": 3.0,
+  "power_recommend_w": { "min": 50, "max": 250 },
+  "max_spl_db_1m": 115,
+  "f_low_f3_hz": 35,
+  "dimensions_mm": { "h": 1245, "w": 267, "d": 372 },
+  "dispersion": { "h_deg": 90, "v_deg": 60 },
+  "directivity_hint": { "woofer_diameter_in": 8, "tweeter_type": "horn", "waveguide": true, "xo_hz": 1500 },
+  "spinorama": { "freq_hz": [], "on_axis_db": [], "listening_window_db": [], "early_reflections_db": [], "sound_power_db": [], "di_listening_window_db": [], "di_sound_power_db": [] },
+  "data_quality": {
+    "tier": "C",
+    "provenance": ["manufacturer specs"],
+    "spin_format": "none",
+    "freq_res_hz": 5,
+    "smoothing_oct": 0.333,
+    "estimation": { "used": true, "methods": ["directivity_template","xo_alignment","woofer_beamwidth"], "notes": "Off-axis estimated from horn + 8in woofer, XO ~1.5 kHz" },
+    "confidence_0_1": 0.55
+  },
+  "sources": []
+}

--- a/data/speakers/KEF_Q350.json
+++ b/data/speakers/KEF_Q350.json
@@ -1,0 +1,25 @@
+{
+  "brand": "KEF",
+  "model": "Q350",
+  "type": "bookshelf",
+  "sensitivity_db": 87.0,
+  "impedance_ohm_nom": 8,
+  "impedance_ohm_min": 3.7,
+  "power_recommend_w": { "min": 25, "max": 120 },
+  "max_spl_db_1m": 108,
+  "f_low_f3_hz": 63,
+  "dimensions_mm": { "h": 358, "w": 210, "d": 306 },
+  "dispersion": { "h_deg": 100, "v_deg": 100 },
+  "directivity_hint": { "woofer_diameter_in": 6.5, "tweeter_type": "concentric", "waveguide": true, "xo_hz": 2500 },
+  "spinorama": { "freq_hz": [], "on_axis_db": [] },
+  "data_quality": {
+    "tier": "C",
+    "provenance": ["manufacturer specs"],
+    "spin_format": "none",
+    "freq_res_hz": 5,
+    "smoothing_oct": 0.333,
+    "estimation": { "used": true, "methods": ["directivity_template"], "notes": "Concentric driver; estimated off-axis" },
+    "confidence_0_1": 0.6
+  },
+  "sources": []
+}

--- a/data/speakers/Revel_F206.json
+++ b/data/speakers/Revel_F206.json
@@ -1,0 +1,25 @@
+{
+  "brand": "Revel",
+  "model": "F206",
+  "type": "floorstanding",
+  "sensitivity_db": 88.5,
+  "impedance_ohm_nom": 8,
+  "impedance_ohm_min": 3.2,
+  "power_recommend_w": { "min": 50, "max": 300 },
+  "max_spl_db_1m": 112,
+  "f_low_f3_hz": 39,
+  "dimensions_mm": { "h": 1054, "w": 221, "d": 307 },
+  "dispersion": { "h_deg": 90, "v_deg": 60 },
+  "directivity_hint": { "woofer_diameter_in": 6.5, "tweeter_type": "dome", "waveguide": true, "xo_hz": 2300 },
+  "spinorama": { "freq_hz": [], "on_axis_db": [] },
+  "data_quality": {
+    "tier": "B",
+    "provenance": ["third-party lab review"],
+    "spin_format": "partial",
+    "freq_res_hz": 2,
+    "smoothing_oct": 0.167,
+    "estimation": { "used": true, "methods": ["partial_to_cta_weights"], "notes": "Partial polars mapped to CTA weights" },
+    "confidence_0_1": 0.75
+  },
+  "sources": []
+}

--- a/index.html
+++ b/index.html
@@ -19,6 +19,8 @@
       .measure-label { position:absolute; pointer-events:none; font-size:12px; background:#1b2330cc; padding:4px 6px; border:1px solid #2a3446; border-radius:6px; transform:translate(-50%,-120%); }
       .tips { margin-top:8px; font-size:12px; color:#b7c1d1; }
       .sep { height:1px; background:#232832; margin:12px 0; }
+      .small .muted { opacity:.85 }
+  [data-tip] { text-decoration-style:dotted; }
     </style>
   </head>
   <body>

--- a/src/lib/accuracy.js
+++ b/src/lib/accuracy.js
@@ -1,0 +1,20 @@
+export function confidenceFromQuality(q) {
+  if (!q) return 0.3;
+  const tierBase = { A: 0.9, B: 0.75, C: 0.5, D: 0.25 }[q.tier] ?? 0.3;
+  const estPenalty = q.estimation?.used ? 0.1 : 0.0;
+  const resBonus = (q.freq_res_hz && q.freq_res_hz <= 2) ? 0.05 : 0;
+  const implicit = Math.min(1, Math.max(0, tierBase - estPenalty + resBonus));
+  return (typeof q.confidence_0_1 === 'number') ? q.confidence_0_1 : implicit;
+}
+
+export function blendScore(modelScore_0_10, confidence_0_1) {
+  // Pull predictions toward a neutral baseline when confidence is low.
+  const baseline = 7.0;
+  return baseline + (modelScore_0_10 - baseline) * (0.5 + 0.5 * confidence_0_1);
+}
+
+export function tierBadge(tier) {
+  const t = (tier || 'D').toUpperCase();
+  const colors = { A: '#20c997', B: '#22b8cf', C: '#fab005', D: '#ff6b6b' };
+  return { label: {A:'Gold',B:'Silver',C:'Bronze',D:'Tin'}[t] || 'Tin', color: colors[t] || colors.D };
+}

--- a/src/lib/persona.js
+++ b/src/lib/persona.js
@@ -1,0 +1,45 @@
+const LS_KEYS = {
+  persona: 'app.persona',
+  tooltips: 'app.tooltipsEnabled',
+  onboardingDone: 'app.onboardingDone'
+};
+
+const PERSONAS = {
+  casual:  { id: 'casual',  label: 'Casual',  showHeatmap: false, showSpinorama: false, exportReport: false, tooltips: true },
+  diy:     { id: 'diy',     label: 'DIY',     showHeatmap: true,  showSpinorama: false, exportReport: false, tooltips: true },
+  pro:     { id: 'pro',     label: 'Pro',     showHeatmap: true,  showSpinorama: true,  exportReport: true,  tooltips: false },
+  reviewer:{ id: 'reviewer',label: 'Reviewer',showHeatmap: true,  showSpinorama: true,  exportReport: true,  tooltips: true }
+};
+
+const DEFAULT_PERSONA = 'diy';
+
+export function getPersona() {
+  return localStorage.getItem(LS_KEYS.persona) || DEFAULT_PERSONA;
+}
+export function setPersona(id) {
+  localStorage.setItem(LS_KEYS.persona, PERSONAS[id] ? id : DEFAULT_PERSONA);
+}
+export function getPersonaConfig() {
+  const id = getPersona();
+  return PERSONAS[id] || PERSONAS[DEFAULT_PERSONA];
+}
+
+export function isTooltipsEnabled() {
+  const v = localStorage.getItem(LS_KEYS.tooltips);
+  if (v === null) return getPersonaConfig().tooltips;
+  return v === 'true';
+}
+export function setTooltipsEnabled(on) {
+  localStorage.setItem(LS_KEYS.tooltips, on ? 'true' : 'false');
+}
+
+export function isOnboardingDone() {
+  return localStorage.getItem(LS_KEYS.onboardingDone) === 'true';
+}
+export function setOnboardingDone(done) {
+  localStorage.setItem(LS_KEYS.onboardingDone, done ? 'true' : 'false');
+}
+
+export function personasList() {
+  return Object.values(PERSONAS);
+}

--- a/src/lib/preference.js
+++ b/src/lib/preference.js
@@ -1,0 +1,7 @@
+export function simplePreferenceScore({ onAxisVarDb = 1, bassF10 = 40, hasSpin = false }) {
+  let score = 7.0;
+  score -= Math.max(0, onAxisVarDb - 1) * 0.5;
+  score += Math.max(0, (60 - Math.min(bassF10, 60)) / 10);
+  score += hasSpin ? 0.5 : -0.5;
+  return Math.max(0, Math.min(10, score));
+}

--- a/src/lib/spl.js
+++ b/src/lib/spl.js
@@ -1,0 +1,10 @@
+export function requiredWattsToHitSPL(targetDb, sensitivityDb, distanceMeters, speakers = 1) {
+  const distanceLoss = 20 * Math.log10(distanceMeters);
+  const neededGain = targetDb - sensitivityDb + distanceLoss;
+  return Math.pow(10, neededGain / 10) / speakers;
+}
+
+export function headroomDb(availableWatts, requiredWatts) {
+  if (!availableWatts || !requiredWatts) return 0;
+  return 10 * Math.log10(availableWatts / requiredWatts);
+}

--- a/src/main.js
+++ b/src/main.js
@@ -1,6 +1,9 @@
 import * as THREE from 'three';
 import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
 import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
+import { mountEquipmentPanel } from './panels/EquipmentPanel.js';
+import { mountOnboarding } from './ui/Onboarding.js';
+import { personasList, getPersona, setPersona, isTooltipsEnabled, setTooltipsEnabled } from './lib/persona.js';
 
 const mToFt = 3.28084;
 
@@ -15,6 +18,34 @@ const measureBtn  = document.getElementById('measureBtn');
 const clearBtn    = document.getElementById('clearMeasure');
 const unitsSel    = document.getElementById('units');
 const labelEl     = document.getElementById('measureLabel');
+(function addSettingsStrip(){
+  const ui = document.getElementById('ui');
+  if (!ui || document.getElementById('settingsStrip')) return;
+  const div = document.createElement('div');
+  div.id = 'settingsStrip';
+  div.style = 'margin-bottom:8px;border-bottom:1px solid #232832;padding-bottom:8px';
+  const persona = getPersona();
+  const opts = personasList().map(p => `<option value="${p.id}" ${p.id===persona?'selected':''}>${p.label}</option>`).join('');
+  div.innerHTML = `
+    <div class="row" style="align-items:center;gap:8px">
+      <label>Persona:
+        <select id="personaSel">${opts}</select>
+      </label>
+      <label>Tooltips:
+        <input id="tipsChk" type="checkbox" ${isTooltipsEnabled()?'checked':''}/>
+      </label>
+      <button id="resetOnb" title="Show first-time persona tutorial again">Run Tutorial</button>
+    </div>
+  `;
+  ui.prepend(div);
+  div.querySelector('#personaSel').onchange = (e)=> setPersona(e.target.value);
+  div.querySelector('#tipsChk').onchange = (e)=> setTooltipsEnabled(e.target.checked);
+  div.querySelector('#resetOnb').onclick = ()=> mountOnboarding(document.body);
+})();
+
+mountEquipmentPanel(document.getElementById('ui'));
+mountOnboarding(document.body);
+
 
 // Renderer / Scene / Camera
 const renderer = new THREE.WebGLRenderer({ antialias: true });

--- a/src/panels/EquipmentPanel.js
+++ b/src/panels/EquipmentPanel.js
@@ -1,0 +1,126 @@
+import { requiredWattsToHitSPL, headroomDb } from '../lib/spl.js';
+import { simplePreferenceScore } from '../lib/preference.js';
+import { confidenceFromQuality, blendScore, tierBadge } from '../lib/accuracy.js';
+import { getPersonaConfig, isTooltipsEnabled, setTooltipsEnabled } from '../lib/persona.js';
+
+async function loadJSON(url) {
+  const r = await fetch(url);
+  if (!r.ok) throw new Error(`HTTP ${r.status} for ${url}`);
+  return r.json();
+}
+
+async function listManifest() {
+  const manifest = await loadJSON('/data/manifest.json');
+  return manifest;
+}
+
+function el(html) {
+  const t = document.createElement('template');
+  t.innerHTML = html.trim();
+  return t.content.firstChild;
+}
+
+function tipAttr(key, text) {
+  return isTooltipsEnabled() ? `data-tip="${key}" title="${text.replace(/"/g,'&quot;')}"` : '';
+}
+
+export function mountEquipmentPanel(container) {
+  const personaCfg = getPersonaConfig();
+  const root = el(`
+    <div style="margin-top:12px">
+      <h2 style="font-size:16px;margin:8px 0">Equipment</h2>
+      <div class="row" ${tipAttr('selectEq','Pick a speaker and amp to evaluate headroom')} >
+        <select id="spSel"></select>
+        <select id="ampSel"></select>
+      </div>
+      <div class="row">
+        <label ${tipAttr('dist','Distance from speaker to listener in meters')}>Distance (m)
+          <input id="dist" type="number" min="1" step="0.1" value="3.0" style="width:80px"/>
+        </label>
+        <label ${tipAttr('tgt','Peak SPL target (cinema: 105 dB LCR)')}>Target Peak (dB)
+          <input id="tgt" type="number" min="85" step="1" value="105" style="width:80px"/>
+        </label>
+      </div>
+      <div id="eqpTier" class="muted" style="margin:6px 0"></div>
+      <div id="eqpStats" class="muted"></div>
+      <div id="eqpWarn" class="muted" style="color:#ffb3b3"></div>
+    </div>
+  `);
+  container.appendChild(root);
+
+  const spSel  = root.querySelector('#spSel');
+  const ampSel = root.querySelector('#ampSel');
+  const distEl = root.querySelector('#dist');
+  const tgtEl  = root.querySelector('#tgt');
+  const tierEl = root.querySelector('#eqpTier');
+  const stats  = root.querySelector('#eqpStats');
+  const warn   = root.querySelector('#eqpWarn');
+
+  let spData = null, ampData = null, manifest = null;
+
+  function renderTier(q) {
+    if (!q) { tierEl.textContent = ''; return; }
+    const { label, color } = tierBadge(q.tier);
+    const confPct = Math.round(confidenceFromQuality(q) * 100);
+    tierEl.innerHTML = `<span style="display:inline-block;padding:2px 8px;border-radius:999px;background:${color};color:#0b0d10;font-weight:600">${label} • ${confPct}% confidence
+    </span>`;
+  }
+
+  function renderStats() {
+    if (!spData || !ampData) { stats.textContent = ''; warn.textContent=''; return; }
+    const distance = parseFloat(distEl.value || '3');
+    const target   = parseFloat(tgtEl.value || '105');
+    const wattsReq = requiredWattsToHitSPL(target, spData.sensitivity_db, distance, 1);
+    const head     = headroomDb(ampData.power_w_8ohm_all || 50, wattsReq);
+
+    const q = spData.data_quality || { tier: 'D' };
+    renderTier(q);
+
+    const rawPref = simplePreferenceScore({
+      onAxisVarDb: 2.0,
+      bassF10: spData.f_low_f3_hz || 40,
+      hasSpin: !!(spData.spinorama && spData.spinorama.freq_hz && spData.spinorama.freq_hz.length)
+    });
+    const conf = confidenceFromQuality(q);
+    const shownPref = blendScore(rawPref, conf);
+
+    stats.innerHTML = `
+      Speaker: <b>${spData.brand} ${spData.model}</b> (Sens ${spData.sensitivity_db} dB, F3 ${spData.f_low_f3_hz} Hz)<br/>
+      Amp: <b>${ampData.brand} ${ampData.model}</b> (8Ω ${ampData.power_w_8ohm_all || 'n/a'} W)<br/>
+      Preference (raw ${rawPref.toFixed(1)}), shown: <b>${shownPref.toFixed(1)}/10</b><br/>
+      Required power @${distance}m for ${target} dB peaks: <b>${wattsReq.toFixed(0)} W</b><br/>
+      Headroom (8Ω rated): <b>${head.toFixed(1)} dB</b>
+    `;
+    warn.textContent = head < 0 ? '⚠️ Underpowered for target SPL at this distance.' : '';
+  }
+
+  function onChange() {
+    const spFile  = spSel.value;
+    const ampFile = ampSel.value;
+    Promise.all([
+      spFile ? loadJSON(`/data/speakers/${spFile}`) : null,
+      ampFile ? loadJSON(`/data/amps/${ampFile}`) : null
+    ]).then(([sp, amp]) => { spData = sp; ampData = amp; renderStats(); });
+  }
+
+  (async () => {
+    manifest = await listManifest();
+    const spList = manifest.speakers || [];
+    const ampList = manifest.amps || [];
+
+    spSel.innerHTML = `<option value="">Select speaker</option>` +
+      spList.map(f => `<option value="${f}">${f.replace('.json','').replace(/_/g,' ')}</option>`).join('');
+    ampSel.innerHTML = `<option value="">Select amp</option>` +
+      ampList.map(f => `<option value="${f}">${f.replace('.json','').replace(/_/g,' ')}</option>`).join('');
+
+    spSel.addEventListener('change', onChange);
+    ampSel.addEventListener('change', onChange);
+    distEl.addEventListener('input', renderStats);
+    tgtEl.addEventListener('input', renderStats);
+
+    // Persona defaults can hide advanced panels later; for now this panel is always visible.
+    if (personaCfg && personaCfg.tooltips === false) {
+      setTooltipsEnabled(false);
+    }
+  })();
+}

--- a/src/ui/Onboarding.js
+++ b/src/ui/Onboarding.js
@@ -1,0 +1,63 @@
+import { personasList, setPersona, isOnboardingDone, setOnboardingDone, setTooltipsEnabled } from '../lib/persona.js';
+
+function css() {
+  if (document.getElementById('onboardCSS')) return;
+  const style = document.createElement('style');
+  style.id = 'onboardCSS';
+  style.textContent = `
+  .ob-backdrop{position:fixed;inset:0;background:rgba(0,0,0,.6);display:flex;align-items:center;justify-content:center;z-index:9999}
+  .ob-card{background:#11141a;border:1px solid #232832;border-radius:12px;max-width:520px;width:92%;padding:16px;color:#e8eaed;box-shadow:0 8px 40px rgba(0,0,0,.6)}
+  .ob-grid{display:grid;grid-template-columns:1fr 1fr;gap:10px;margin:12px 0}
+  .ob-btn{border:1px solid #2a3140;background:#0f131a;color:#e8eaed;padding:10px;border-radius:10px;cursor:pointer}
+  .ob-btn:hover{background:#16202b}
+  .ob-row{display:flex;justify-content:space-between;align-items:center;margin-top:8px}
+  `;
+  document.head.appendChild(style);
+}
+
+export function mountOnboarding(root=document.body) {
+  if (isOnboardingDone()) return;
+  css();
+  const wrap = document.createElement('div');
+  wrap.className = 'ob-backdrop';
+  wrap.innerHTML = `
+    <div class="ob-card">
+      <h2 style="margin:0 0 8px 0">Choose how you’ll use the app</h2>
+      <div style="opacity:.8">You can change this later in Settings.</div>
+      <div class="ob-grid" id="obGrid"></div>
+      <div class="ob-row">
+        <label><input id="obTips" type="checkbox" checked/> Show tooltips</label>
+        <div>
+          <button class="ob-btn" id="obSkip">Skip</button>
+          <button class="ob-btn" id="obDone">Done</button>
+        </div>
+      </div>
+      <label style="display:block;margin-top:8px;"><input id="obDont" type="checkbox"/> Don’t show again</label>
+    </div>
+  `;
+  const grid = wrap.querySelector('#obGrid');
+  const tips = wrap.querySelector('#obTips');
+  const dont = wrap.querySelector('#obDont');
+
+  let selected = null;
+  personasList().forEach(p => {
+    const b = document.createElement('button');
+    b.className = 'ob-btn';
+    b.textContent = `${p.label}`;
+    b.onclick = () => { selected = p.id; [...grid.children].forEach(c=>c.style.outline=''); b.style.outline='2px solid #22b8cf'; };
+    grid.appendChild(b);
+  });
+
+  wrap.querySelector('#obSkip').onclick = () => {
+    setOnboardingDone(dont.checked);
+    root.removeChild(wrap);
+  };
+  wrap.querySelector('#obDone').onclick = () => {
+    if (selected) setPersona(selected);
+    setTooltipsEnabled(!!tips.checked);
+    setOnboardingDone(dont.checked);
+    root.removeChild(wrap);
+  };
+
+  root.appendChild(wrap);
+}


### PR DESCRIPTION
## Summary
- add accuracy helpers for confidence and tier badges
- include data_quality metadata for seed speaker files and add amp data
- implement equipment panel with confidence-adjusted scores
- introduce persona onboarding with tooltip controls and settings strip
- ensure manifest lists speakers/amps and tweak tooltip styles

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aba1c6e73c8331937f38ed5a9bceee