### PR TITLE
Phase-1 wrap-up with predictable structure and data seeds

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,29 @@
 # Media-Room-Cal-Sim (Starter)
 
 Open `public/index.html` to test viewer.
+
+## How to run
+
+```bash
+npm i && npm run dev
+```
+
+## LF Heatmap
+
+Toggle the **LF Heatmap** checkbox and adjust the L/W/H inputs to view the low-frequency heatmap.
+
+## Spinorama import
+
+```bash
+node tools/import_spinorama.mjs data/speakers/JBL_Studio_590.json /path/to/spin.csv
+```
+
+Expected CSV headers: `Frequency (Hz)`, `OnAxis (dB)`, `ListeningWindow (dB)`, `EarlyReflections (dB)`, `SoundPower (dB)`, `SoundPowerDI (dB)`.
+
+## Report export
+
+Use the **Export PNG** and **Export JSON** buttons in the UI to generate reports.
+
+## Accuracy tiers & confidence badges
+
+Speaker files include a data quality tier (A–F) and confidence level. The equipment panel displays tier and confidence badges for the selected speaker.

--- a/data/amps/Anthem_MRX_540.json
+++ b/data/amps/Anthem_MRX_540.json
@@ -1,0 +1,7 @@
+{
+  "brand": "Anthem",
+  "model": "MRX 540",
+  "power_w_2ch": 100,
+  "power_w_5ch": 80,
+  "notes": ""
+}

--- a/data/amps/Denon_X1700H.json
+++ b/data/amps/Denon_X1700H.json
@@ -1,0 +1,7 @@
+{
+  "brand": "Denon",
+  "model": "X1700H",
+  "power_w_2ch": 80,
+  "power_w_5ch": 60,
+  "notes": ""
+}

--- a/data/amps/Yamaha_A4A.json
+++ b/data/amps/Yamaha_A4A.json
@@ -1,0 +1,7 @@
+{
+  "brand": "Yamaha",
+  "model": "A4A",
+  "power_w_2ch": 110,
+  "power_w_5ch": 90,
+  "notes": ""
+}

--- a/data/manifest.json
+++ b/data/manifest.json
@@ -1,0 +1,14 @@
+{
+  "speakers": [
+    "JBL_Studio_590",
+    "SVS_Ultra_Bookshelf",
+    "KEF_Q350",
+    "Elac_Debut_2_0_B6_2",
+    "Polk_LSiM703"
+  ],
+  "amps": [
+    "Denon_X1700H",
+    "Yamaha_A4A",
+    "Anthem_MRX_540"
+  ]
+}

--- a/data/speakers/Elac_Debut_2_0_B6_2.json
+++ b/data/speakers/Elac_Debut_2_0_B6_2.json
@@ -1,0 +1,10 @@
+{
+  "brand": "Elac",
+  "model": "Debut 2.0 B6.2",
+  "type": "bookshelf",
+  "sensitivity_db_2v83_1m": 87,
+  "impedance_ohm_nominal": 6,
+  "max_spl_db_pair": 106,
+  "data_quality": { "tier": "C", "confidence_0_1": 0.5 },
+  "spinorama": null
+}

--- a/data/speakers/JBL_Studio_590.json
+++ b/data/speakers/JBL_Studio_590.json
@@ -1,0 +1,10 @@
+{
+  "brand": "JBL",
+  "model": "Studio 590",
+  "type": "tower",
+  "sensitivity_db_2v83_1m": 91,
+  "impedance_ohm_nominal": 6,
+  "max_spl_db_pair": 112,
+  "data_quality": { "tier": "C", "confidence_0_1": 0.55 },
+  "spinorama": null
+}

--- a/data/speakers/KEF_Q350.json
+++ b/data/speakers/KEF_Q350.json
@@ -1,0 +1,10 @@
+{
+  "brand": "KEF",
+  "model": "Q350",
+  "type": "bookshelf",
+  "sensitivity_db_2v83_1m": 87,
+  "impedance_ohm_nominal": 8,
+  "max_spl_db_pair": 110,
+  "data_quality": { "tier": "B", "confidence_0_1": 0.6 },
+  "spinorama": null
+}

--- a/data/speakers/Polk_LSiM703.json
+++ b/data/speakers/Polk_LSiM703.json
@@ -1,0 +1,10 @@
+{
+  "brand": "Polk",
+  "model": "LSiM703",
+  "type": "bookshelf",
+  "sensitivity_db_2v83_1m": 88,
+  "impedance_ohm_nominal": 8,
+  "max_spl_db_pair": 109,
+  "data_quality": { "tier": "B", "confidence_0_1": 0.6 },
+  "spinorama": null
+}

--- a/data/speakers/SVS_Ultra_Bookshelf.json
+++ b/data/speakers/SVS_Ultra_Bookshelf.json
@@ -1,0 +1,10 @@
+{
+  "brand": "SVS",
+  "model": "Ultra Bookshelf",
+  "type": "bookshelf",
+  "sensitivity_db_2v83_1m": 87,
+  "impedance_ohm_nominal": 8,
+  "max_spl_db_pair": 108,
+  "data_quality": { "tier": "B", "confidence_0_1": 0.65 },
+  "spinorama": null
+}

--- a/src/Main.js
+++ b/src/Main.js
@@ -1,6 +1,8 @@
 import * as THREE from 'three';
 import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
 import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
+import { ensureOnboarding } from './ui/Onboarding.js';
+import { mountEquipmentPanel } from './panels/EquipmentPanel.js';
 
 const mToFt = 3.28084;
 
@@ -15,6 +17,9 @@ const measureBtn  = document.getElementById('measureBtn');
 const clearBtn    = document.getElementById('clearMeasure');
 const unitsSel    = document.getElementById('units');
 const labelEl     = document.getElementById('measureLabel');
+
+ensureOnboarding();
+mountEquipmentPanel(document);
 
 // Renderer / Scene / Camera
 const renderer = new THREE.WebGLRenderer({ antialias: true });

--- a/src/lib/accuracy.js
+++ b/src/lib/accuracy.js
@@ -1,0 +1,8 @@
+export function tierToBadge(tier='C') {
+  const map = { A:'#2ecc71', B:'#3498db', C:'#f1c40f', D:'#e67e22', F:'#e74c3c' };
+  return { label: tier, color: map[tier] || '#bdc3c7' };
+}
+export function confidenceToPercent(v=0.5) {
+  const n = Math.max(0, Math.min(1, Number(v)));
+  return Math.round(n * 100);
+}

--- a/src/lib/persona.js
+++ b/src/lib/persona.js
@@ -1,0 +1,7 @@
+const KEY = 'app.persona';
+export function getPersona() {
+  return localStorage.getItem(KEY) || 'diy'; // casual|diy|pro|reviewer
+}
+export function setPersona(id) {
+  localStorage.setItem(KEY, id);
+}

--- a/src/main.js
+++ b/src/main.js
@@ -1,0 +1,1 @@
+import './Main.js';

--- a/src/panels/EquipmentPanel.js
+++ b/src/panels/EquipmentPanel.js
@@ -1,0 +1,54 @@
+import { tierToBadge, confidenceToPercent } from '../lib/accuracy.js';
+
+export function mountEquipmentPanel(root=document) {
+  const wrap = root.getElementById('equipPanel') || root.getElementById('ui');
+  if (!wrap) return;
+
+  // Speaker selector (expects a <select id="spSel"> if index.html already has it)
+  let spSel = root.getElementById('spSel');
+  if (!spSel) {
+    const row = document.createElement('div');
+    row.className = 'row';
+    row.innerHTML = `
+      <label>Speaker:
+        <select id="spSel">
+          <option value="">(select)</option>
+        </select>
+      </label>
+      <span id="spBadges"></span>`;
+    wrap.appendChild(row);
+    spSel = row.querySelector('#spSel');
+  }
+
+  // Load manifest if available and populate
+  fetch('/data/manifest.json').then(r => r.ok ? r.json() : null).then(async (man) => {
+    if (!man?.speakers) return;
+    for (const id of man.speakers) {
+      const o = document.createElement('option');
+      o.value = id;
+      o.textContent = id.replace(/_/g,' ');
+      spSel.appendChild(o);
+    }
+  }).catch(()=>{});
+
+  spSel?.addEventListener('change', async () => {
+    const val = spSel.value;
+    const badgeWrap = root.getElementById('spBadges');
+    if (!val || !badgeWrap) return;
+    badgeWrap.textContent = '';
+    try {
+      const sp = await (await fetch(`/data/speakers/${val}.json`)).json();
+      const tier = sp?.data_quality?.tier || 'C';
+      const conf = confidenceToPercent(sp?.data_quality?.confidence_0_1 ?? 0.5);
+      const t = tierToBadge(tier);
+      const bTier = document.createElement('span');
+      bTier.textContent = `Tier ${t.label}`;
+      bTier.style.cssText = `display:inline-block;padding:2px 8px;border-radius:999px;margin-right:6px;color:#0b0d10;background:${t.color}`;
+      const bConf = document.createElement('span');
+      bConf.textContent = `${conf}% conf.`;
+      bConf.style.cssText = `display:inline-block;padding:2px 8px;border-radius:999px;margin-right:6px;background:#34495e;color:#ecf0f1`;
+      badgeWrap.appendChild(bTier);
+      badgeWrap.appendChild(bConf);
+    } catch {}
+  });
+}

--- a/src/ui/Onboarding.js
+++ b/src/ui/Onboarding.js
@@ -1,0 +1,19 @@
+export function ensureOnboarding(root=document.body) {
+  const SEEN = 'app.onboarding.seen';
+  if (localStorage.getItem(SEEN)==='1') return;
+  const tip = document.createElement('div');
+  tip.style.cssText = 'position:fixed;right:16px;bottom:16px;background:#11141a;color:#e8eaed;border:1px solid #232832;padding:12px;border-radius:12px;max-width:340px;z-index:9999';
+  tip.innerHTML = `
+    <b>Welcome!</b><br>
+    • Load a GLB or click <em>Load Sample</em>.<br>
+    • Orbit with mouse; use grid/axes toggles.<br>
+    • Try LF Heatmap and Export buttons.<br>
+    <div style="margin-top:8px;text-align:right">
+      <button id="obGotIt">Got it</button>
+    </div>`;
+  root.appendChild(tip);
+  tip.querySelector('#obGotIt').onclick = () => {
+    localStorage.setItem(SEEN, '1');
+    tip.remove();
+  };
+}


### PR DESCRIPTION
## Summary
- Normalize entry point via lowercase shim and call to Main
- Implement accuracy/persona utilities, onboarding bubble, and equipment panel
- Seed sample manifest, speaker, and amp JSON files
- Document running the app, heatmap usage, spinorama import, export buttons, and badge meaning
- Wire onboarding and equipment panel in Main

## Testing
- `npm run dev` *(fails: vite not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/three)*

------
https://chatgpt.com/codex/tasks/task_e_68abcadb600c8331aac7c7db6d473d28