### PR TITLE
Commerce: Catalog + Cart + Checkout (affiliate & direct stub) + Quote export

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,25 @@
 # Media-Room-Cal-Sim (Starter)
 
 Open `public/index.html` to test viewer.
+
+## Commerce
+
+- Catalog files in `data/catalog/*.json` follow:
+  ```json
+  {
+    "sku": "SKU",
+    "brand": "Brand",
+    "model": "Model",
+    "category": "speaker",
+    "price_usd": 0,
+    "images": [],
+    "affiliate": { "retailer": "https://..." },
+    "badges": { "tier": "A", "confidence": 0.9 },
+    "notes": "",
+    "options": []
+  }
+  ```
+- Cart persists in `localStorage` and can check out via **Affiliate** links or a stub **Direct** flow.
+- Add your affiliate IDs by editing the links in catalog JSON.
+- Test: select equipment → "Add to Cart" → open Cart → Checkout.
+- "Export Quote" saves a PNG snapshot and cart JSON.

--- a/data/catalog/amps.json
+++ b/data/catalog/amps.json
@@ -1,0 +1,14 @@
+[
+  {
+    "sku": "AMP-100",
+    "brand": "Acme",
+    "model": "100W",
+    "category": "amp",
+    "price_usd": 499.0,
+    "images": ["/images/amp.png"],
+    "affiliate": {},
+    "badges": { "tier": "B", "confidence": 0.8 },
+    "notes": "Entry amp",
+    "options": []
+  }
+]

--- a/data/catalog/panels.json
+++ b/data/catalog/panels.json
@@ -1,0 +1,14 @@
+[
+  {
+    "sku": "PANEL-A1",
+    "brand": "PanelCo",
+    "model": "Acoustic Panel",
+    "category": "panel",
+    "price_usd": 59.0,
+    "images": ["/images/panel.png"],
+    "affiliate": {},
+    "badges": { "tier": "A", "confidence": 0.95 },
+    "notes": "",
+    "options": []
+  }
+]

--- a/data/catalog/speakers.json
+++ b/data/catalog/speakers.json
@@ -1,0 +1,16 @@
+[
+  {
+    "sku": "JBL-590",
+    "brand": "JBL",
+    "model": "Studio 590",
+    "category": "speaker",
+    "price_usd": 999.0,
+    "images": ["/images/jbl590.png"],
+    "affiliate": {
+      "amazon": "https://example.com/jbl590?tag=AFF"
+    },
+    "badges": { "tier": "A", "confidence": 0.9 },
+    "notes": "Floorstanding; good to 55 Hz in-room",
+    "options": []
+  }
+]

--- a/data/catalog/subs.json
+++ b/data/catalog/subs.json
@@ -1,0 +1,14 @@
+[
+  {
+    "sku": "SUB-10",
+    "brand": "SubCo",
+    "model": "10in",
+    "category": "sub",
+    "price_usd": 299.0,
+    "images": ["/images/sub.png"],
+    "affiliate": {},
+    "badges": { "tier": "C", "confidence": 0.7 },
+    "notes": "",
+    "options": []
+  }
+]

--- a/index.html
+++ b/index.html
@@ -40,6 +40,10 @@
         </div>
 
         <div class="row">
+          <button id="btnCart">Cart (0)</button>
+        </div>
+
+        <div class="row">
           <label><input type="checkbox" id="gridT" checked /> Grid</label>
           <label><input type="checkbox" id="axesT" checked /> Axes</label>
         </div>

--- a/src/commerce/checkout.js
+++ b/src/commerce/checkout.js
@@ -1,0 +1,18 @@
+export async function checkoutAffiliate(cart) {
+  const win = window.open('', '_blank');
+  if (!win) return { ok: false };
+  win.document.write('<h1>Checkout</h1>');
+  cart.items.forEach(it => {
+    if (!it.affiliate) return;
+    win.document.write(`<h3>${it.brand} ${it.model}</h3>`);
+    for (const [name, url] of Object.entries(it.affiliate)) {
+      win.document.write(`<div><a href="${url}" target="_blank">${name}</a></div>`);
+    }
+  });
+  return { ok: true };
+}
+
+export async function checkoutDirect(cart) {
+  alert('Direct checkout not yet enabled.');
+  return { ok: false, message: 'Direct checkout not yet enabled' };
+}

--- a/src/lib/cart.js
+++ b/src/lib/cart.js
@@ -1,0 +1,53 @@
+const stored = localStorage.getItem('app.cart');
+
+function persist(cart) {
+  localStorage.setItem('app.cart', JSON.stringify(cart.items));
+  localStorage.setItem('checkout.mode', cart.mode);
+}
+
+function emit() {
+  window.dispatchEvent(new CustomEvent('cart:change'));
+}
+
+export const cart = {
+  items: stored ? JSON.parse(stored) : [],
+  mode: localStorage.getItem('checkout.mode') || 'affiliate',
+  add(item, qty = 1) {
+    const existing = this.items.find(i => i.sku === item.sku);
+    if (existing) existing.qty += qty;
+    else this.items.push({ ...item, qty });
+    persist(this);
+    emit();
+  },
+  remove(sku) {
+    this.items = this.items.filter(i => i.sku !== sku);
+    persist(this);
+    emit();
+  },
+  setQty(sku, qty) {
+    const it = this.items.find(i => i.sku === sku);
+    if (it) {
+      it.qty = qty;
+      if (it.qty <= 0) this.remove(sku);
+      persist(this);
+      emit();
+    }
+  },
+  subtotal() {
+    return this.items.reduce((s, i) => s + i.price_usd * i.qty, 0);
+  },
+  clear() {
+    this.items = [];
+    persist(this);
+    emit();
+  },
+  toJSON() {
+    return { items: this.items, mode: this.mode };
+  },
+  fromJSON(data) {
+    this.items = data.items || [];
+    this.mode = data.mode || this.mode;
+    persist(this);
+    emit();
+  }
+};

--- a/src/lib/catalog.js
+++ b/src/lib/catalog.js
@@ -1,0 +1,33 @@
+let catalog = null;
+
+export async function loadCatalog() {
+  if (catalog) return catalog;
+  const cats = ['speakers', 'amps', 'subs', 'panels'];
+  const data = { allBySku: {} };
+  for (const c of cats) {
+    try {
+      const res = await fetch(`/data/catalog/${c}.json`);
+      const arr = res.ok ? await res.json() : [];
+      data[c] = arr;
+      for (const item of arr) data.allBySku[item.sku] = item;
+    } catch (e) {
+      data[c] = [];
+    }
+  }
+  catalog = data;
+  return catalog;
+}
+
+export function findSku(sku) {
+  return catalog && catalog.allBySku[sku];
+}
+
+export function searchCatalog(q) {
+  if (!catalog) return [];
+  q = (q || '').toLowerCase();
+  return Object.values(catalog.allBySku).filter(it =>
+    it.sku.toLowerCase().includes(q) ||
+    it.brand.toLowerCase().includes(q) ||
+    it.model.toLowerCase().includes(q)
+  );
+}

--- a/src/lib/report.js
+++ b/src/lib/report.js
@@ -1,0 +1,24 @@
+export function captureCanvasPNG(canvas) {
+  const url = canvas.toDataURL('image/png');
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = 'quote.png';
+  a.click();
+}
+
+export function downloadQuotePDFLike(canvas, cartSnapshot) {
+  captureCanvasPNG(canvas);
+  const state = typeof window.collectState === 'function' ? window.collectState() : {};
+  const json = {
+    cart: cartSnapshot,
+    room: state.room || null,
+    selection: state.selection || null
+  };
+  const blob = new Blob([JSON.stringify(json, null, 2)], { type: 'application/json' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = 'quote.json';
+  a.click();
+  URL.revokeObjectURL(url);
+}

--- a/src/main.js
+++ b/src/main.js
@@ -4,6 +4,10 @@ import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
 import { mountEquipmentPanel } from './panels/EquipmentPanel.js';
 import { mountOnboarding } from './ui/Onboarding.js';
 import { personasList, getPersona, setPersona, isTooltipsEnabled, setTooltipsEnabled } from './lib/persona.js';
+import { loadCatalog } from './lib/catalog.js';
+import { cart } from './lib/cart.js';
+import { mountCartPanel } from './ui/CartPanel.js';
+import { checkoutAffiliate, checkoutDirect } from './commerce/checkout.js';
 
 const mToFt = 3.28084;
 
@@ -42,6 +46,18 @@ const labelEl     = document.getElementById('measureLabel');
   div.querySelector('#tipsChk').onchange = (e)=> setTooltipsEnabled(e.target.checked);
   div.querySelector('#resetOnb').onclick = ()=> mountOnboarding(document.body);
 })();
+
+await loadCatalog();
+async function handleCheckout(mode = cart.mode) {
+  if (mode === 'affiliate') return checkoutAffiliate(cart);
+  return checkoutDirect(cart);
+}
+const cartPanel = mountCartPanel({ rootEl: document.body, onCheckout: handleCheckout });
+const btnCart = document.getElementById('btnCart');
+btnCart.onclick = () => cartPanel.toggle();
+function updateCartBtn() { btnCart.textContent = `Cart (${cart.items.reduce((a,i)=>a+i.qty,0)})`; }
+window.addEventListener('cart:change', updateCartBtn);
+updateCartBtn();
 
 mountEquipmentPanel(document.getElementById('ui'));
 mountOnboarding(document.body);

--- a/src/ui/Badges.js
+++ b/src/ui/Badges.js
@@ -1,0 +1,9 @@
+import { tierBadge, confidenceFromQuality } from '../lib/accuracy.js';
+
+export function renderBadges(item) {
+  if (!item || !item.badges) return '';
+  const { tier, confidence } = item.badges;
+  const { label, color } = tierBadge(tier);
+  const conf = Math.round((confidence || confidenceFromQuality(item.badges)) * 100);
+  return `<span style="display:inline-block;padding:2px 6px;border-radius:8px;background:${color};color:#0b0d10;font-size:10px;margin-right:4px">${label}</span><span class="muted">${conf}%</span>`;
+}

--- a/src/ui/CartPanel.js
+++ b/src/ui/CartPanel.js
@@ -1,0 +1,76 @@
+import { cart } from '../lib/cart.js';
+import { renderBadges } from './Badges.js';
+import { downloadQuotePDFLike } from '../lib/report.js';
+
+export function mountCartPanel({ rootEl, onCheckout }) {
+  const panel = document.createElement('div');
+  panel.id = 'cartPanel';
+  panel.innerHTML = `
+    <h2 style="margin-top:0">Cart</h2>
+    <div id="cartItems"></div>
+    <div id="cartSub" style="margin:8px 0"></div>
+    <label>Mode:
+      <select id="checkoutMode">
+        <option value="affiliate">Affiliate</option>
+        <option value="direct">Direct</option>
+      </select>
+    </label>
+    <div class="row" style="margin-top:8px;gap:8px">
+      <button id="btnCheckout" class="primary">Checkout</button>
+      <button id="btnQuote">Export Quote</button>
+    </div>
+    <div id="cartRecs" style="margin-top:12px;font-size:12px;opacity:.8"><small>based on items in cart</small></div>
+  `;
+  panel.style = 'position:fixed;top:0;right:-320px;width:320px;height:100%;background:#11141a;border-left:1px solid #232832;padding:16px;transition:right .3s;overflow:auto;z-index:2000';
+  rootEl.appendChild(panel);
+
+  const style = document.createElement('style');
+  style.textContent = `#cartPanel.open{right:0} #cartPanel img{width:48px;height:48px;object-fit:cover;border-radius:4px}`;
+  document.head.appendChild(style);
+
+  function render() {
+    const list = panel.querySelector('#cartItems');
+    list.innerHTML = cart.items.map(it => `
+      <div class="row" style="align-items:center;margin:6px 0">
+        <img src="${(it.images && it.images[0]) || ''}" alt=""/>
+        <div style="flex:1">
+          <div>${it.brand} ${it.model}</div>
+          <div class="muted" style="font-size:11px">${renderBadges(it)}</div>
+        </div>
+        <div style="text-align:right">
+          $${(it.price_usd * it.qty).toFixed(2)}<br/>
+          <button data-act="dec" data-sku="${it.sku}">-</button>
+          <span>${it.qty}</span>
+          <button data-act="inc" data-sku="${it.sku}">+</button>
+          <button data-act="rem" data-sku="${it.sku}" title="Remove">x</button>
+        </div>
+      </div>
+    `).join('');
+    panel.querySelector('#cartSub').textContent = `Subtotal: $${cart.subtotal().toFixed(2)} (tax est.)`;
+    panel.querySelector('#checkoutMode').value = cart.mode;
+  }
+  render();
+  window.addEventListener('cart:change', render);
+
+  panel.addEventListener('click', e => {
+    const sku = e.target.dataset.sku;
+    const act = e.target.dataset.act;
+    if (!sku || !act) return;
+    if (act === 'inc') cart.setQty(sku, cart.items.find(i=>i.sku===sku).qty + 1);
+    if (act === 'dec') cart.setQty(sku, cart.items.find(i=>i.sku===sku).qty - 1);
+    if (act === 'rem') cart.remove(sku);
+  });
+
+  panel.querySelector('#checkoutMode').onchange = e => {
+    cart.mode = e.target.value;
+    localStorage.setItem('checkout.mode', cart.mode);
+    window.dispatchEvent(new CustomEvent('cart:change'));
+  };
+  panel.querySelector('#btnCheckout').onclick = () => onCheckout && onCheckout(cart.mode);
+  panel.querySelector('#btnQuote').onclick = () => {
+    const canvas = document.querySelector('canvas');
+    downloadQuotePDFLike(canvas, cart.toJSON());
+  };
+
+  return { toggle: () => panel.classList.toggle('open') };
+}


### PR DESCRIPTION
## Summary
- add catalog JSON and loader utilities
- implement cart state with persistence, UI drawer and quote export
- add checkout flows: affiliate link summary and direct stub

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: vite: not found)*
- `npm run dev` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68abf3ce558c8331ba960c4a6ecd338e