### PR TITLE
Commerce bootstrap: basic catalog and cart

### DIFF
--- a/data/catalog/JBL_590.json
+++ b/data/catalog/JBL_590.json
@@ -1,0 +1,6 @@
+{
+  "sku": "JBL-590",
+  "brand": "JBL",
+  "model": "Studio 590",
+  "price_usd": 999.00
+}

--- a/data/catalog/Yamaha_RXA.json
+++ b/data/catalog/Yamaha_RXA.json
@@ -1,0 +1,6 @@
+{
+  "sku": "Yamaha-RXA",
+  "brand": "Yamaha",
+  "model": "RX-A",
+  "price_usd": 1099.00
+}

--- a/data/catalog/manifest.json
+++ b/data/catalog/manifest.json
@@ -1,0 +1,6 @@
+{
+  "products": [
+    "JBL_590.json",
+    "Yamaha_RXA.json"
+  ]
+}

--- a/src/commerce/checkout.js
+++ b/src/commerce/checkout.js
@@ -1,0 +1,3 @@
+export function checkout(cart) {
+  console.log('Checkout order', cart);
+}

--- a/src/lib/catalog.js
+++ b/src/lib/catalog.js
@@ -1,0 +1,19 @@
+let catalogCache = null;
+
+export async function loadCatalog() {
+  if (catalogCache) return catalogCache;
+  const res = await fetch('/data/catalog/manifest.json');
+  if (!res.ok) throw new Error('Failed to load catalog manifest');
+  const manifest = await res.json();
+  const items = [];
+  for (const file of manifest.products || []) {
+    const r = await fetch(`/data/catalog/${file}`);
+    if (r.ok) items.push(await r.json());
+  }
+  catalogCache = items;
+  return items;
+}
+
+export function getCatalog() {
+  return catalogCache;
+}

--- a/src/main.js
+++ b/src/main.js
@@ -4,6 +4,7 @@ import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
 import { mountEquipmentPanel } from './panels/EquipmentPanel.js';
 import { mountOnboarding } from './ui/Onboarding.js';
 import { personasList, getPersona, setPersona, isTooltipsEnabled, setTooltipsEnabled } from './lib/persona.js';
+import { mountCartPanel } from './ui/CartPanel.js';
 
 const mToFt = 3.28084;
 
@@ -18,6 +19,7 @@ const measureBtn  = document.getElementById('measureBtn');
 const clearBtn    = document.getElementById('clearMeasure');
 const unitsSel    = document.getElementById('units');
 const labelEl     = document.getElementById('measureLabel');
+let cart;
 (function addSettingsStrip(){
   const ui = document.getElementById('ui');
   if (!ui || document.getElementById('settingsStrip')) return;
@@ -35,16 +37,19 @@ const labelEl     = document.getElementById('measureLabel');
         <input id="tipsChk" type="checkbox" ${isTooltipsEnabled()?'checked':''}/>
       </label>
       <button id="resetOnb" title="Show first-time persona tutorial again">Run Tutorial</button>
+      <button id="cartBtn">Cart</button>
     </div>
   `;
   ui.prepend(div);
   div.querySelector('#personaSel').onchange = (e)=> setPersona(e.target.value);
   div.querySelector('#tipsChk').onchange = (e)=> setTooltipsEnabled(e.target.checked);
   div.querySelector('#resetOnb').onclick = ()=> mountOnboarding(document.body);
+  div.querySelector('#cartBtn').onclick = ()=> cart && cart.toggle();
 })();
 
 mountEquipmentPanel(document.getElementById('ui'));
 mountOnboarding(document.body);
+cart = mountCartPanel();
 
 
 // Renderer / Scene / Camera

--- a/src/ui/CartPanel.js
+++ b/src/ui/CartPanel.js
@@ -1,0 +1,62 @@
+import { loadCatalog } from '../lib/catalog.js';
+import { checkout } from '../commerce/checkout.js';
+
+export function mountCartPanel() {
+  const root = document.createElement('div');
+  root.id = 'cartPanel';
+  root.style = 'position:fixed;right:20px;top:60px;width:300px;background:#1f2a3a;padding:12px;color:#d8e1f0;display:none;z-index:1000';
+  root.innerHTML = `
+    <h3 style="margin-top:0">Catalog</h3>
+    <ul id="catalogList"></ul>
+    <h3>Cart</h3>
+    <ul id="cartList"></ul>
+    <div>Total: $<span id="cartTotal">0.00</span></div>
+    <button id="checkoutBtn">Checkout</button>
+  `;
+  document.body.appendChild(root);
+
+  const catalogList = root.querySelector('#catalogList');
+  const cartList    = root.querySelector('#cartList');
+  const totalEl     = root.querySelector('#cartTotal');
+  const checkoutBtn = root.querySelector('#checkoutBtn');
+
+  const cart = [];
+
+  loadCatalog().then(items => {
+    items.forEach(item => {
+      const li  = document.createElement('li');
+      li.textContent = `${item.brand} ${item.model} - $${item.price_usd}`;
+      const btn = document.createElement('button');
+      btn.textContent = 'Add';
+      btn.onclick = () => { cart.push(item); renderCart(); };
+      li.appendChild(btn);
+      catalogList.appendChild(li);
+    });
+  });
+
+  function renderCart() {
+    cartList.innerHTML = '';
+    let total = 0;
+    cart.forEach((item, idx) => {
+      total += item.price_usd;
+      const li = document.createElement('li');
+      li.textContent = `${item.brand} ${item.model} - $${item.price_usd}`;
+      const btn = document.createElement('button');
+      btn.textContent = 'Remove';
+      btn.onclick = () => { cart.splice(idx,1); renderCart(); };
+      li.appendChild(btn);
+      cartList.appendChild(li);
+    });
+    totalEl.textContent = total.toFixed(2);
+  }
+
+  checkoutBtn.onclick = () => checkout(cart);
+
+  return {
+    show: () => (root.style.display = 'block'),
+    hide: () => (root.style.display = 'none'),
+    toggle: () => {
+      root.style.display = root.style.display === 'none' ? 'block' : 'none';
+    }
+  };
+}


### PR DESCRIPTION
## Summary
- add sample catalog data and manifest
- load catalog via `src/lib/catalog.js`
- basic CartPanel with add/remove items and total and checkout stub
- wire Cart button into main UI

## Testing
- `npm install` *(fails: 403 Forbidden from registry)*
- `npm run dev` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68abf611662c8331b0b54573c26ab1ec