### PR TITLE
feat: add speaker object manager

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,12 +6,16 @@
   "scripts": {
     "start": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run"
   },
   "dependencies": {
-    "three": "^0.155.0"
+    "three": "^0.155.0",
+    "uuid": "^9.0.0",
+    "zustand": "^4.5.0"
   },
   "devDependencies": {
-    "vite": "^5.2.0"
+    "vite": "^5.2.0",
+    "vitest": "^1.5.0"
   }
 }

--- a/src/state/projectStore.ts
+++ b/src/state/projectStore.ts
@@ -1,0 +1,139 @@
+import { createStore, StoreApi } from 'zustand/vanilla';
+import { v4 as uuidv4 } from 'uuid';
+import type { Project, Speaker, Vec3 } from '../types/room';
+
+export interface ProjectState {
+  project: Project;
+  undoStack: Project[];
+  redoStack: Project[];
+  canUndo: boolean;
+  canRedo: boolean;
+  dispatch: (cmd: Command) => void;
+  undo: () => void;
+  redo: () => void;
+}
+
+export type Command =
+  | { type: 'addSpeaker'; model: string; pos?: Vec3; rotY?: number }
+  | { type: 'selectSpeaker'; id: string | null }
+  | { type: 'moveSpeaker'; id: string; pos: Vec3 }
+  | { type: 'deleteSpeaker'; id: string };
+
+const VERSION = '1';
+const DATA_KEY = 'project/current';
+const VER_KEY = 'project/version';
+
+const defaultProject: Project = { speakers: [], selectedId: null };
+
+function save(project: Project) {
+  try {
+    localStorage.setItem(DATA_KEY, JSON.stringify(project));
+    localStorage.setItem(VER_KEY, VERSION);
+  } catch {}
+}
+
+function hydrate(): Project {
+  try {
+    if (localStorage.getItem(VER_KEY) === VERSION) {
+      const raw = localStorage.getItem(DATA_KEY);
+      if (raw) return JSON.parse(raw) as Project;
+    }
+  } catch {}
+  return { ...defaultProject };
+}
+
+function reduce(project: Project, cmd: Command): Project {
+  switch (cmd.type) {
+    case 'addSpeaker': {
+      const id = uuidv4();
+      const speaker: Speaker = {
+        id,
+        model: cmd.model,
+        pos: cmd.pos ? { ...cmd.pos } : { x: 0, y: 0, z: 0 },
+        rotY: cmd.rotY || 0,
+      };
+      return {
+        speakers: [...project.speakers, speaker],
+        selectedId: id,
+      };
+    }
+    case 'selectSpeaker': {
+      return { ...project, selectedId: cmd.id };
+    }
+    case 'moveSpeaker': {
+      const speakers = project.speakers.map((s) =>
+        s.id === cmd.id ? { ...s, pos: { ...cmd.pos, y: 0 } } : s
+      );
+      return { ...project, speakers };
+    }
+    case 'deleteSpeaker': {
+      const speakers = project.speakers.filter((s) => s.id !== cmd.id);
+      const selectedId = project.selectedId === cmd.id ? null : project.selectedId;
+      return { speakers, selectedId };
+    }
+    default:
+      return project;
+  }
+}
+
+export function createProjectStore(initial?: Project): StoreApi<ProjectState> {
+  const proj = initial || hydrate();
+  const store = createStore<ProjectState>((set, get) => ({
+    project: proj,
+    undoStack: [],
+    redoStack: [],
+    canUndo: false,
+    canRedo: false,
+    dispatch: (cmd: Command) => {
+      set((state) => {
+        const prev = state.project;
+        const next = reduce(prev, cmd);
+        const undoStack = [...state.undoStack, prev];
+        const newState = {
+          project: next,
+          undoStack,
+          redoStack: [],
+          canUndo: undoStack.length > 0,
+          canRedo: false,
+        };
+        save(next);
+        return newState;
+      });
+    },
+    undo: () => {
+      set((state) => {
+        if (state.undoStack.length === 0) return state;
+        const prev = state.undoStack[state.undoStack.length - 1];
+        const undoStack = state.undoStack.slice(0, -1);
+        const redoStack = [...state.redoStack, state.project];
+        save(prev);
+        return {
+          project: prev,
+          undoStack,
+          redoStack,
+          canUndo: undoStack.length > 0,
+          canRedo: true,
+        };
+      });
+    },
+    redo: () => {
+      set((state) => {
+        if (state.redoStack.length === 0) return state;
+        const next = state.redoStack[state.redoStack.length - 1];
+        const redoStack = state.redoStack.slice(0, -1);
+        const undoStack = [...state.undoStack, state.project];
+        save(next);
+        return {
+          project: next,
+          undoStack,
+          redoStack,
+          canUndo: true,
+          canRedo: redoStack.length > 0,
+        };
+      });
+    },
+  }));
+  return store;
+}
+
+export const projectStore = createProjectStore();

--- a/src/three/interaction/DragController.ts
+++ b/src/three/interaction/DragController.ts
@@ -1,0 +1,49 @@
+import type { StoreApi } from 'zustand/vanilla';
+import type { ProjectState } from '../../state/projectStore';
+import { RaycastController } from './RaycastController';
+
+const SNAP = 0.0762; // 0.25 ft in meters
+const snap = (v: number, g: number) => Math.round(v / g) * g;
+
+export class DragController {
+  private store: StoreApi<ProjectState>;
+  private ray: RaycastController;
+  private dom: HTMLElement;
+  private dragging = false;
+
+  constructor(store: StoreApi<ProjectState>, ray: RaycastController, dom: HTMLElement) {
+    this.store = store;
+    this.ray = ray;
+    this.dom = dom;
+    dom.addEventListener('pointerdown', this.onDown);
+    dom.addEventListener('pointerup', this.onUp);
+    ray.addEventListener('move', this.onMove as EventListener);
+  }
+
+  private onDown = () => {
+    const { project } = this.store.getState();
+    if (project.selectedId) {
+      this.dragging = true;
+    }
+  };
+
+  private onUp = () => {
+    this.dragging = false;
+  };
+
+  private onMove = (e: Event) => {
+    if (!this.dragging) return;
+    const detail = (e as CustomEvent).detail;
+    if (!detail) return;
+    const { world } = detail as { world: { x: number; y: number; z: number } };
+    const { project, dispatch } = this.store.getState();
+    if (!project.selectedId) return;
+    dispatch({
+      type: 'moveSpeaker',
+      id: project.selectedId,
+      pos: { x: snap(world.x, SNAP), y: 0, z: snap(world.z, SNAP) },
+    });
+  };
+}
+
+export { snap };

--- a/src/three/interaction/RaycastController.ts
+++ b/src/three/interaction/RaycastController.ts
@@ -1,0 +1,29 @@
+import * as THREE from 'three';
+import type { Vec3 } from '../../types/room';
+
+export class RaycastController extends EventTarget {
+  private camera: THREE.Camera;
+  private dom: HTMLElement;
+  private raycaster = new THREE.Raycaster();
+  private plane = new THREE.Plane(new THREE.Vector3(0, 1, 0), 0);
+  private vec = new THREE.Vector3();
+
+  constructor(camera: THREE.Camera, dom: HTMLElement) {
+    super();
+    this.camera = camera;
+    this.dom = dom;
+    dom.addEventListener('pointermove', this.onMove);
+  }
+
+  private onMove = (e: PointerEvent) => {
+    const rect = this.dom.getBoundingClientRect();
+    const ndc = new THREE.Vector2(
+      ((e.clientX - rect.left) / rect.width) * 2 - 1,
+      -((e.clientY - rect.top) / rect.height) * 2 + 1
+    );
+    this.raycaster.setFromCamera(ndc, this.camera);
+    this.raycaster.ray.intersectPlane(this.plane, this.vec);
+    const world: Vec3 = { x: this.vec.x, y: 0, z: this.vec.z };
+    this.dispatchEvent(new CustomEvent('move', { detail: { world } }));
+  };
+}

--- a/src/three/objects/SpeakerMesh.ts
+++ b/src/three/objects/SpeakerMesh.ts
@@ -1,0 +1,25 @@
+import * as THREE from 'three';
+import type { Speaker } from '../../types/room';
+
+export type SpeakerMesh = THREE.Mesh & { setSelected: (selected: boolean) => void };
+
+export function createSpeakerMesh(data: Speaker): SpeakerMesh {
+  const geom = new THREE.BoxGeometry(0.3, 0.3, 0.3);
+  const mat = new THREE.MeshStandardMaterial({ color: 0x555555 });
+  const mesh = new THREE.Mesh(geom, mat) as SpeakerMesh;
+  mesh.position.set(data.pos.x, data.pos.y, data.pos.z);
+  mesh.rotation.y = data.rotY;
+
+  const edges = new THREE.LineSegments(
+    new THREE.EdgesGeometry(geom),
+    new THREE.LineBasicMaterial({ color: 0xffff00 })
+  );
+  edges.visible = false;
+  mesh.add(edges);
+
+  mesh.setSelected = (selected: boolean) => {
+    edges.visible = selected;
+  };
+
+  return mesh;
+}

--- a/src/types/room.ts
+++ b/src/types/room.ts
@@ -1,0 +1,17 @@
+export interface Vec3 {
+  x: number;
+  y: number;
+  z: number;
+}
+
+export interface Speaker {
+  id: string;
+  model: string;
+  pos: Vec3;
+  rotY: number;
+}
+
+export interface Project {
+  speakers: Speaker[];
+  selectedId: string | null;
+}

--- a/src/ui/LeftDock/SpeakerPanel.tsx
+++ b/src/ui/LeftDock/SpeakerPanel.tsx
@@ -1,0 +1,55 @@
+import { projectStore } from '../../state/projectStore';
+
+const MODELS = ['Model A', 'Model B'];
+
+export function mountSpeakerPanel(container: HTMLElement) {
+  const root = document.createElement('div');
+  const modelSel = document.createElement('select');
+  MODELS.forEach((m) => {
+    const opt = document.createElement('option');
+    opt.value = m;
+    opt.textContent = m;
+    modelSel.appendChild(opt);
+  });
+  const addBtn = document.createElement('button');
+  addBtn.textContent = 'Add Speaker';
+  const list = document.createElement('ul');
+  const delBtn = document.createElement('button');
+  delBtn.textContent = 'Delete';
+  const undoBtn = document.createElement('button');
+  undoBtn.textContent = 'Undo';
+  const redoBtn = document.createElement('button');
+  redoBtn.textContent = 'Redo';
+
+  root.append(modelSel, addBtn, list, delBtn, undoBtn, redoBtn);
+  container.appendChild(root);
+
+  addBtn.onclick = () => {
+    const model = modelSel.value || MODELS[0];
+    projectStore.getState().dispatch({ type: 'addSpeaker', model });
+  };
+  delBtn.onclick = () => {
+    const { project, dispatch } = projectStore.getState();
+    if (project.selectedId) dispatch({ type: 'deleteSpeaker', id: project.selectedId });
+  };
+  undoBtn.onclick = () => projectStore.getState().undo();
+  redoBtn.onclick = () => projectStore.getState().redo();
+
+  function render() {
+    const { project, canUndo, canRedo } = projectStore.getState();
+    list.innerHTML = '';
+    project.speakers.forEach((s) => {
+      const li = document.createElement('li');
+      li.textContent = s.model;
+      li.style.cursor = 'pointer';
+      if (s.id === project.selectedId) li.style.fontWeight = 'bold';
+      li.onclick = () => projectStore.getState().dispatch({ type: 'selectSpeaker', id: s.id });
+      list.appendChild(li);
+    });
+    delBtn.disabled = !project.selectedId;
+    undoBtn.disabled = !canUndo;
+    redoBtn.disabled = !canRedo;
+  }
+  render();
+  projectStore.subscribe(render);
+}

--- a/src/viewer/SceneGraph.ts
+++ b/src/viewer/SceneGraph.ts
@@ -1,0 +1,41 @@
+import * as THREE from 'three';
+import { projectStore } from '../state/projectStore';
+import { createSpeakerMesh, SpeakerMesh } from '../three/objects/SpeakerMesh';
+
+export class SceneGraph {
+  private scene: THREE.Scene;
+  private meshes = new Map<string, SpeakerMesh>();
+
+  constructor(scene: THREE.Scene) {
+    this.scene = scene;
+    projectStore.subscribe(() => this.sync());
+    this.sync();
+  }
+
+  private sync() {
+    const { project } = projectStore.getState();
+    const ids = new Set(project.speakers.map((s) => s.id));
+
+    // remove missing
+    for (const [id, mesh] of this.meshes) {
+      if (!ids.has(id)) {
+        this.scene.remove(mesh);
+        this.meshes.delete(id);
+      }
+    }
+
+    // add/update
+    for (const sp of project.speakers) {
+      let mesh = this.meshes.get(sp.id);
+      if (!mesh) {
+        mesh = createSpeakerMesh(sp);
+        this.meshes.set(sp.id, mesh);
+        this.scene.add(mesh);
+      } else {
+        mesh.position.set(sp.pos.x, sp.pos.y, sp.pos.z);
+        mesh.rotation.y = sp.rotY;
+      }
+      mesh.setSelected(sp.id === project.selectedId);
+    }
+  }
+}

--- a/tests/projectStore.test.ts
+++ b/tests/projectStore.test.ts
@@ -1,0 +1,77 @@
+/* @vitest-environment jsdom */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { createProjectStore } from '../src/state/projectStore';
+
+const pos = { x: 1, y: 0, z: 2 };
+
+describe('projectStore', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('adds and selects speaker', () => {
+    const store = createProjectStore();
+    store.getState().dispatch({ type: 'addSpeaker', model: 'A', pos });
+    const state = store.getState();
+    expect(state.project.speakers).toHaveLength(1);
+    const id = state.project.speakers[0].id;
+    expect(state.project.selectedId).toBe(id);
+    // persisted
+    const raw = localStorage.getItem('project/current');
+    expect(raw && JSON.parse(raw).speakers).toHaveLength(1);
+  });
+
+  it('moves speaker', () => {
+    const store = createProjectStore();
+    store.getState().dispatch({ type: 'addSpeaker', model: 'A', pos });
+    const id = store.getState().project.selectedId!;
+    store.getState().dispatch({ type: 'moveSpeaker', id, pos: { x: 2, y: 0, z: 3 } });
+    const sp = store.getState().project.speakers[0];
+    expect(sp.pos).toEqual({ x: 2, y: 0, z: 3 });
+  });
+
+  it('deletes speaker', () => {
+    const store = createProjectStore();
+    store.getState().dispatch({ type: 'addSpeaker', model: 'A', pos });
+    const id = store.getState().project.selectedId!;
+    store.getState().dispatch({ type: 'deleteSpeaker', id });
+    expect(store.getState().project.speakers).toHaveLength(0);
+    expect(store.getState().project.selectedId).toBeNull();
+  });
+
+  it('undo and redo', () => {
+    const store = createProjectStore();
+    // add two speakers
+    store.getState().dispatch({ type: 'addSpeaker', model: 'A', pos });
+    const id1 = store.getState().project.selectedId!;
+    store.getState().dispatch({ type: 'addSpeaker', model: 'B', pos });
+    const id2 = store.getState().project.selectedId!;
+    // select first
+    store.getState().dispatch({ type: 'selectSpeaker', id: id1 });
+    expect(store.getState().project.selectedId).toBe(id1);
+    // undo selection -> should select id2
+    store.getState().undo();
+    expect(store.getState().project.selectedId).toBe(id2);
+    // undo add B -> left with A selected
+    store.getState().undo();
+    expect(store.getState().project.speakers).toHaveLength(1);
+    expect(store.getState().project.selectedId).toBe(id1);
+    // redo add B
+    store.getState().redo();
+    expect(store.getState().project.speakers).toHaveLength(2);
+    // redo selection
+    store.getState().redo();
+    expect(store.getState().project.selectedId).toBe(id1);
+  });
+
+  it('persists to localStorage', () => {
+    const store = createProjectStore();
+    store.getState().dispatch({ type: 'addSpeaker', model: 'A', pos });
+    const id = store.getState().project.selectedId!;
+    store.getState().dispatch({ type: 'moveSpeaker', id, pos: { x: 4, y: 0, z: 5 } });
+    // create new store -> hydrate
+    const store2 = createProjectStore();
+    const sp = store2.getState().project.speakers[0];
+    expect(sp.pos).toEqual({ x: 4, y: 0, z: 5 });
+  });
+});


### PR DESCRIPTION
## Summary
- add room, speaker, and project types
- implement project store with undo/redo and persistence
- scaffold speaker meshes, raycast & drag controllers, and UI panel
- add scene graph integration and unit tests

## Testing
- `npm run build`
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68adf1d6c7d48331864568464cf14c42