### PR TITLE
feat: add dark theme layout scaffold

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,66 +4,43 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Room Viewer</title>
-    <style>
-      :root { color-scheme: dark; }
-      html,body { margin:0; height:100%; background:#0b0d10; color:#e8eaed; font-family:system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial; }
-      #app { position:fixed; inset:0; display:grid; grid-template-columns: 1fr 340px; }
-      #view { position:relative; background:#0b0d10; }
-      #ui { background:#11141a; border-left:1px solid #232832; padding:14px; overflow:auto; }
-      h1 { font-size:20px; margin:0 0 8px; }
-      .row { display:flex; align-items:center; gap:8px; margin:8px 0; }
-      .muted { opacity:.85; font-size:12px; }
-      button,select,input[type="file"] { background:#1a1f29; color:#e8eaed; border:1px solid #30384a; border-radius:6px; padding:6px 10px; }
-      button.primary { background:#2a6bf2; border-color:#2a6bf2; }
-      button.tog.on { background:#2b3a53; border-color:#3d4a63; }
-      .measure-label { position:absolute; pointer-events:none; font-size:12px; background:#1b2330cc; padding:4px 6px; border:1px solid #2a3446; border-radius:6px; transform:translate(-50%,-120%); }
-      .tips { margin-top:8px; font-size:12px; color:#b7c1d1; }
-      .sep { height:1px; background:#232832; margin:12px 0; }
-      .small .muted { opacity:.85 }
-  [data-tip] { text-decoration-style:dotted; }
-    </style>
+    <link rel="stylesheet" href="/src/styles/layout.css" />
   </head>
-  <body>
-    <div id="app">
-      <div id="view">
-        <!-- dynamic canvas goes here -->
-        <div id="measureLabel" class="measure-label" style="display:none">0.00 m</div>
-      </div>
+  <body class="theme-dark">
+    <div id="app" class="layout">
+      <header id="appHeader" class="hdr">
+        <div class="hdr__title">Navigation</div>
+        <button id="btnFullscreen" class="icon-btn" aria-label="Toggle Fullscreen" title="Fullscreen"></button>
+      </header>
 
-      <div id="ui">
-        <h1>Viewer</h1>
-        <div class="muted">Pick a .glb or use the sample.</div>
-
-        <div class="row">
-          <input type="file" id="file" accept=".glb,.gltf" />
-          <button id="loadSample">Load Sample</button>
+      <aside id="panelLeft" class="panel panel--left">
+        <div class="panel__hdr">
+          <div class="panel__title">Controls</div>
+          <button class="panel__toggle" data-target="panelLeft" aria-label="Collapse/Expand"></button>
         </div>
-
-        <div class="row">
-          <label><input type="checkbox" id="gridT" checked /> Grid</label>
-          <label><input type="checkbox" id="axesT" checked /> Axes</label>
+        <div class="panel__body" id="panelLeftBody">
+          <!-- (intentionally empty; feature wiring will come later) -->
         </div>
+      </aside>
 
-        <div class="sep"></div>
+      <main id="view" class="viewer">
+        <!-- three.js canvas is appended here by existing code -->
+        <div class="viewer__placeholder">Viewer</div>
+      </main>
 
-        <div class="row">
-          <button id="measureBtn" class="tog">Measure</button>
-          <select id="units">
-            <option value="m">Meters</option>
-            <option value="ft">Feet</option>
-          </select>
-          <button id="clearMeasure">Clear</button>
+      <aside id="panelRight" class="panel panel--right">
+        <div class="panel__hdr">
+          <div class="panel__title">Equipment</div>
+          <button class="panel__toggle" data-target="panelRight" aria-label="Collapse/Expand"></button>
         </div>
-
-        <div id="stats" class="muted"></div>
-        <div class="tips">
-          Tip: drag & drop a GLB anywhere in the left panel.<br/>
-          Esc = cancel/clear current measurement.
+        <div class="panel__body" id="panelRightBody">
+          <!-- (intentionally empty; feature wiring will come later) -->
         </div>
-      </div>
+      </aside>
     </div>
 
-    <!-- ESM entry -->
+    <!-- keep your existing main app script; add layout after it -->
     <script type="module" src="/src/main.js"></script>
+    <script type="module" src="/src/ui/layout.js"></script>
   </body>
 </html>

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -1,0 +1,138 @@
+:root {
+  --bg: #0f1115;
+  --bg-panel: #151821;
+  --fg: #e6e6e6;
+  --line: rgba(255,255,255,0.08);
+}
+
+body.theme-dark {
+  background: var(--bg);
+  color: var(--fg);
+}
+
+.layout {
+  display: grid;
+  grid-template-rows: 56px 1fr;
+  grid-template-columns: 280px minmax(0,1fr) 320px;
+  grid-template-areas:
+    "hdr hdr hdr"
+    "left view right";
+  height: 100vh;
+  width: 100vw;
+  overflow: hidden;
+}
+
+.hdr {
+  grid-area: hdr;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 12px;
+  background: var(--bg-panel);
+  border-bottom: 1px solid var(--line);
+}
+
+.panel {
+  background: var(--bg-panel);
+  border-right: 1px solid var(--line);
+  overflow: hidden;
+}
+.panel--left {
+  grid-area: left;
+  min-width: 0;
+}
+.panel--right {
+  grid-area: right;
+  border-left: 1px solid var(--line);
+  border-right: none;
+  min-width: 0;
+}
+
+.panel__hdr {
+  position: sticky;
+  top: 0;
+  height: 44px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 10px;
+  border-bottom: 1px solid var(--line);
+  background: var(--bg-panel);
+  z-index: 1;
+}
+
+.panel__body {
+  padding: 10px;
+  overflow: auto;
+  height: calc(100% - 44px);
+}
+
+.viewer {
+  grid-area: view;
+  position: relative;
+  background: #0b0d12;
+}
+.viewer__placeholder {
+  position: absolute;
+  inset: 12px;
+  border: 1px dashed var(--line);
+  border-radius: 8px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0.4;
+  font-size: 12px;
+}
+
+.icon-btn,
+.panel__toggle {
+  width: 28px;
+  height: 28px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: transparent;
+  color: var(--fg);
+  cursor: pointer;
+}
+
+.panel__toggle::before {
+  content: "▾";
+  display: block;
+  transform: rotate(0deg);
+  text-align: center;
+}
+#panelLeft.is-collapsed .panel__toggle::before {
+  transform: rotate(-90deg);
+}
+#panelRight.is-collapsed .panel__toggle::before {
+  transform: rotate(90deg);
+}
+
+#btnFullscreen::before {
+  content: "⤢";
+}
+
+#panelLeft.is-collapsed {
+  width: 0 !important;
+  min-width: 0;
+  border-right: none;
+}
+#panelLeft.is-collapsed .panel__body {
+  display: none;
+}
+#panelRight.is-collapsed {
+  width: 0 !important;
+  min-width: 0;
+  border-left: none;
+}
+#panelRight.is-collapsed .panel__body {
+  display: none;
+}
+
+.layout.is-fullscreen {
+  grid-template-columns: 0 minmax(0,1fr) 0;
+}
+.layout.is-fullscreen #panelLeft,
+.layout.is-fullscreen #panelRight {
+  display: none;
+}

--- a/src/ui/layout.js
+++ b/src/ui/layout.js
@@ -1,0 +1,81 @@
+// Minimal layout state management for panels and fullscreen
+
+document.addEventListener('DOMContentLoaded', () => {
+  const qs = (s) => document.querySelector(s);
+  const app = qs('#app');
+  const left = qs('#panelLeft');
+  const right = qs('#panelRight');
+  const btnFS = qs('#btnFullscreen');
+  const toggles = document.querySelectorAll('.panel__toggle');
+  const view = qs('#view');
+
+  const KEY_L = 'ui.leftCollapsed';
+  const KEY_R = 'ui.rightCollapsed';
+  const KEY_F = 'ui.fullscreen';
+
+  function getState() {
+    return {
+      leftCollapsed: localStorage.getItem(KEY_L) === 'true',
+      rightCollapsed: localStorage.getItem(KEY_R) === 'true',
+      fullscreen: localStorage.getItem(KEY_F) === 'true',
+    };
+  }
+
+  function saveState(s) {
+    localStorage.setItem(KEY_L, String(!!s.leftCollapsed));
+    localStorage.setItem(KEY_R, String(!!s.rightCollapsed));
+    localStorage.setItem(KEY_F, String(!!s.fullscreen));
+  }
+
+  function applyState(s) {
+    if (left) {
+      left.classList.toggle('is-collapsed', !!s.leftCollapsed);
+      left.style.width = s.leftCollapsed ? '0' : '';
+      const body = left.querySelector('.panel__body');
+      if (body) body.style.display = s.leftCollapsed ? 'none' : '';
+    }
+    if (right) {
+      right.classList.toggle('is-collapsed', !!s.rightCollapsed);
+      right.style.width = s.rightCollapsed ? '0' : '';
+      const body = right.querySelector('.panel__body');
+      if (body) body.style.display = s.rightCollapsed ? 'none' : '';
+    }
+    if (app) app.classList.toggle('is-fullscreen', !!s.fullscreen);
+  }
+
+  let state = getState();
+  applyState(state);
+
+  toggles.forEach((btn) => {
+    btn.addEventListener('click', () => {
+      const targetId = btn.getAttribute('data-target');
+      if (!targetId) return;
+      const el = document.getElementById(targetId);
+      if (!el) return;
+      const key = targetId === 'panelLeft' ? 'leftCollapsed' : 'rightCollapsed';
+      state[key] = !state[key];
+      applyState(state);
+      saveState(state);
+    });
+  });
+
+  btnFS?.addEventListener('click', () => {
+    state.fullscreen = !state.fullscreen;
+    applyState(state);
+    saveState(state);
+  });
+
+  // Keep canvas sized if present
+  if (view) {
+    const ro = new ResizeObserver(() => {
+      const canvas = view.querySelector('canvas');
+      if (canvas) {
+        const { width, height } = view.getBoundingClientRect();
+        canvas.style.width = width + 'px';
+        canvas.style.height = height + 'px';
+      }
+    });
+    ro.observe(view);
+  }
+});
+


### PR DESCRIPTION
## Summary
- implement responsive grid layout with dark theme
- add collapsible left/right panels, top header, fullscreen toggle
- persist UI state in localStorage

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68afbd745a28833196f34a0a5415beed