### PR TITLE
feat: add responsive layout scaffold

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,48 +22,71 @@
       .small .muted { opacity:.85 }
   [data-tip] { text-decoration-style:dotted; }
     </style>
+    <link rel="stylesheet" href="/src/styles/layout.css" />
   </head>
   <body>
     <div id="app">
+      <header id="appHeader">
+        <div class="hdr__title">Navigation</div>
+        <button id="btnFullscreen" title="Fullscreen" aria-label="Fullscreen"></button>
+      </header>
+
+      <aside id="panelLeft">
+        <div class="panel__hdr">
+          <div class="panel__title">Controls</div>
+          <button class="panel__toggle" data-target="panelLeft" aria-label="Collapse/Expand"></button>
+        </div>
+        <div class="panel__body" id="panelLeftBody">
+          <div id="ui">
+            <h1>Viewer</h1>
+            <div class="muted">Pick a .glb or use the sample.</div>
+
+            <div class="row">
+              <input type="file" id="file" accept=".glb,.gltf" />
+              <button id="loadSample">Load Sample</button>
+            </div>
+
+            <div class="row">
+              <label><input type="checkbox" id="gridT" checked /> Grid</label>
+              <label><input type="checkbox" id="axesT" checked /> Axes</label>
+            </div>
+
+            <div class="sep"></div>
+
+            <div class="row">
+              <button id="measureBtn" class="tog">Measure</button>
+              <select id="units">
+                <option value="m">Meters</option>
+                <option value="ft">Feet</option>
+              </select>
+              <button id="clearMeasure">Clear</button>
+            </div>
+
+            <div id="stats" class="muted"></div>
+            <div class="tips">
+              Tip: drag & drop a GLB anywhere in the left panel.<br/>
+              Esc = cancel/clear current measurement.
+            </div>
+          </div>
+        </div>
+      </aside>
+
       <div id="view">
         <!-- dynamic canvas goes here -->
         <div id="measureLabel" class="measure-label" style="display:none">0.00 m</div>
       </div>
 
-      <div id="ui">
-        <h1>Viewer</h1>
-        <div class="muted">Pick a .glb or use the sample.</div>
-
-        <div class="row">
-          <input type="file" id="file" accept=".glb,.gltf" />
-          <button id="loadSample">Load Sample</button>
+      <aside id="panelRight">
+        <div class="panel__hdr">
+          <div class="panel__title">Equipment</div>
+          <button class="panel__toggle" data-target="panelRight" aria-label="Collapse/Expand"></button>
         </div>
-
-        <div class="row">
-          <label><input type="checkbox" id="gridT" checked /> Grid</label>
-          <label><input type="checkbox" id="axesT" checked /> Axes</label>
-        </div>
-
-        <div class="sep"></div>
-
-        <div class="row">
-          <button id="measureBtn" class="tog">Measure</button>
-          <select id="units">
-            <option value="m">Meters</option>
-            <option value="ft">Feet</option>
-          </select>
-          <button id="clearMeasure">Clear</button>
-        </div>
-
-        <div id="stats" class="muted"></div>
-        <div class="tips">
-          Tip: drag & drop a GLB anywhere in the left panel.<br/>
-          Esc = cancel/clear current measurement.
-        </div>
-      </div>
+        <div class="panel__body" id="panelRightBody"></div>
+      </aside>
     </div>
 
     <!-- ESM entry -->
     <script type="module" src="/src/main.js"></script>
+    <script type="module" src="/src/ui/layout.js"></script>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -68,6 +68,15 @@
               Esc = cancel/clear current measurement.
             </div>
           </div>
+          <div class="group" id="objControlsSection">
+            <div class="group__title">Object Controls</div>
+            <label style="display:flex;gap:6px;align-items:center;">
+              <input id="chkSnap" type="checkbox" checked />
+              <span>Snap</span>
+              <input id="snapSize" type="number" step="0.001" min="0" value="0.0762" style="width:90px;" />
+              <span class="muted">m</span>
+            </label>
+          </div>
         </div>
       </aside>
 
@@ -75,6 +84,26 @@
         <!-- dynamic canvas goes here -->
         <div id="measureLabel" class="measure-label" style="display:none">0.00 m</div>
       </div>
+
+      <section id="panelBottom">
+        <div class="panel__hdr">
+          <div class="panel__title">Viewer Controls</div>
+          <button class="panel__toggle" data-target="panelBottom" aria-label="Collapse/Expand"></button>
+        </div>
+        <div class="panel__body" id="panelBottomBody">
+          <div id="objToolbar" class="viewer-toolbar" data-role="viewer-toolbar">
+            <button id="toolSelect">Select</button>
+            <button id="toolTranslate">Move (W)</button>
+            <button id="toolRotate">Rotate (E)</button>
+            <span class="sep"></span>
+            <button id="btnDuplicate">Duplicate (Ctrl/Cmd+D)</button>
+            <button id="btnDeleteObj">Delete (Del)</button>
+            <span class="sep"></span>
+            <button id="btnUndoObj">Undo</button>
+            <button id="btnRedoObj">Redo</button>
+          </div>
+        </div>
+      </section>
 
       <aside id="panelRight">
         <div class="panel__hdr">
@@ -89,5 +118,6 @@
     <script type="module" src="/src/main.js"></script>
     <script type="module" src="/src/ui/layout.js"></script>
     <script type="module" src="/src/ui/layout-enforce.js"></script>
+    <script type="module" src="/src/ui/toolbar-objects.js"></script>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -27,14 +27,24 @@
   <body>
     <div id="app">
       <header id="appHeader">
-        <div class="hdr__title">Navigation</div>
-        <button id="btnFullscreen" title="Fullscreen" aria-label="Fullscreen"></button>
+        <div class="panel__hdr">
+          <div class="panel__title">Navigation</div>
+          <div class="panel__actions">
+            <button class="panel__collapse" data-target="appHeader" title="Collapse" aria-label="Collapse">▾</button>
+            <button class="panel__fs" data-target="appHeader" title="Fullscreen" aria-label="Fullscreen">⤢</button>
+            <button id="btnFullscreen" title="Fullscreen" aria-label="Fullscreen">⛶</button>
+          </div>
+        </div>
+        <div class="panel__body" id="appHeaderBody"></div>
       </header>
 
       <aside id="panelLeft">
         <div class="panel__hdr">
           <div class="panel__title">Controls</div>
-          <button class="panel__toggle" data-target="panelLeft" aria-label="Collapse/Expand"></button>
+          <div class="panel__actions">
+            <button class="panel__collapse" data-target="panelLeft" title="Collapse" aria-label="Collapse">▾</button>
+            <button class="panel__fs" data-target="panelLeft" title="Fullscreen" aria-label="Fullscreen">⤢</button>
+          </div>
         </div>
         <div class="panel__body" id="panelLeftBody">
           <div id="ui">
@@ -88,7 +98,10 @@
       <section id="panelBottom">
         <div class="panel__hdr">
           <div class="panel__title">Viewer Controls</div>
-          <button class="panel__toggle" data-target="panelBottom" aria-label="Collapse/Expand"></button>
+          <div class="panel__actions">
+            <button class="panel__collapse" data-target="panelBottom" title="Collapse" aria-label="Collapse">▾</button>
+            <button class="panel__fs" data-target="panelBottom" title="Fullscreen" aria-label="Fullscreen">⤢</button>
+          </div>
         </div>
         <div class="panel__body" id="panelBottomBody">
           <div id="objToolbar" class="viewer-toolbar" data-role="viewer-toolbar">
@@ -108,7 +121,10 @@
       <aside id="panelRight">
         <div class="panel__hdr">
           <div class="panel__title">Equipment</div>
-          <button class="panel__toggle" data-target="panelRight" aria-label="Collapse/Expand"></button>
+          <div class="panel__actions">
+            <button class="panel__collapse" data-target="panelRight" title="Collapse" aria-label="Collapse">▾</button>
+            <button class="panel__fs" data-target="panelRight" title="Fullscreen" aria-label="Fullscreen">⤢</button>
+          </div>
         </div>
         <div class="panel__body" id="panelRightBody"></div>
       </aside>
@@ -116,9 +132,9 @@
 
     <!-- ESM entry -->
     <script type="module" src="/src/main.js"></script>
-    <script type="module" src="/src/ui/layout.js"></script>
     <script type="module" src="/src/ui/layout-enforce.js"></script>
-      <script type="module" src="/src/ui/toolbar-objects.js"></script>
-      <script type="module" src="/src/ui/resize-bottom.js"></script>
+    <script type="module" src="/src/ui/toolbar-objects.js"></script>
+    <script type="module" src="/src/ui/panels.js"></script>
+    <script type="module" src="/src/ui/resize-panels.js"></script>
     </body>
   </html>

--- a/index.html
+++ b/index.html
@@ -88,5 +88,6 @@
     <!-- ESM entry -->
     <script type="module" src="/src/main.js"></script>
     <script type="module" src="/src/ui/layout.js"></script>
+    <script type="module" src="/src/ui/layout-enforce.js"></script>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -118,6 +118,7 @@
     <script type="module" src="/src/main.js"></script>
     <script type="module" src="/src/ui/layout.js"></script>
     <script type="module" src="/src/ui/layout-enforce.js"></script>
-    <script type="module" src="/src/ui/toolbar-objects.js"></script>
-  </body>
-</html>
+      <script type="module" src="/src/ui/toolbar-objects.js"></script>
+      <script type="module" src="/src/ui/resize-bottom.js"></script>
+    </body>
+  </html>

--- a/index.html
+++ b/index.html
@@ -136,5 +136,6 @@
     <script type="module" src="/src/ui/toolbar-objects.js"></script>
     <script type="module" src="/src/ui/panels.js"></script>
     <script type="module" src="/src/ui/resize-panels.js"></script>
+    <script type="module" src="/src/ui/layout.js"></script>
     </body>
   </html>

--- a/src/lib/fullscreen-guard.js
+++ b/src/lib/fullscreen-guard.js
@@ -1,0 +1,20 @@
+export function installFullscreenGuard(appEl) {
+  function exitFS() {
+    try { document.exitFullscreen?.(); } catch {}
+    appEl?.classList.remove('is-fullscreen');
+    document.body.classList.remove('is-fullscreen');
+    localStorage.setItem('ui.fullscreen', 'false');
+    window.dispatchEvent(new Event('resize'));
+  }
+
+  window.addEventListener('keydown', e => {
+    if (e.key === 'Escape') { e.stopImmediatePropagation(); e.preventDefault(); exitFS(); }
+  }, true);
+
+  document.addEventListener('fullscreenchange', () => {
+    if (!document.fullscreenElement) exitFS();
+  });
+
+  // Debug helper
+  window.exitFS = exitFS;
+}

--- a/src/main.js
+++ b/src/main.js
@@ -4,6 +4,7 @@ import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
 import { DRACOLoader } from 'three/examples/jsm/loaders/DRACOLoader.js';
 import { mountEquipmentPanel } from './panels/EquipmentPanel.js';
 import { mountOnboarding } from './ui/Onboarding.js';
+import { mountObjectToolbar } from './ui/toolbar-objects.js';
 import { personasList, getPersona, setPersona, isTooltipsEnabled, setTooltipsEnabled } from './lib/persona.js';
 import { LFHeatmapLayer } from './render/LFHeatmapLayer.js';
 import { captureCanvasPNG, downloadBlobURL, generateRoomReport, exportHeatmapData } from './lib/report.js';
@@ -100,6 +101,8 @@ scene.add(grid);
 
 const axes = new THREE.AxesHelper(2);
 scene.add(axes);
+
+mountObjectToolbar({ scene, camera, controls, renderer });
 
 // Initialize new systems
 let lfHeatmap = null;

--- a/src/main.js
+++ b/src/main.js
@@ -9,6 +9,7 @@ import { personasList, getPersona, setPersona, isTooltipsEnabled, setTooltipsEna
 import { LFHeatmapLayer } from './render/LFHeatmapLayer.js';
 import { captureCanvasPNG, downloadBlobURL, generateRoomReport, exportHeatmapData } from './lib/report.js';
 import { BadgeManager } from './ui/Badges.js';
+import { installFullscreenGuard } from './lib/fullscreen-guard.js';
 
 const mToFt = 3.28084;
 
@@ -23,6 +24,23 @@ const measureBtn  = document.getElementById('measureBtn');
 const clearBtn    = document.getElementById('clearMeasure');
 const unitsSel    = document.getElementById('units');
 const labelEl     = document.getElementById('measureLabel');
+const app         = document.getElementById('app');
+const btnFullscreen = document.getElementById('btnFullscreen');
+installFullscreenGuard(app);
+btnFullscreen?.addEventListener('click', async () => {
+  if (!document.fullscreenElement) {
+    try {
+      await app.requestFullscreen?.();
+      app.classList.add('is-fullscreen');
+      document.body.classList.add('is-fullscreen');
+      localStorage.setItem('ui.fullscreen', 'true');
+    } catch (e) {
+      console.warn('Failed to enter fullscreen', e);
+    }
+  } else {
+    window.exitFS?.();
+  }
+});
 
 // New UI elements
 const roomLengthInput = document.getElementById('roomLength');

--- a/src/state/projectStore.ts
+++ b/src/state/projectStore.ts
@@ -17,6 +17,8 @@ export type Command =
   | { type: 'addSpeaker'; model: string; pos?: Vec3; rotY?: number }
   | { type: 'selectSpeaker'; id: string | null }
   | { type: 'moveSpeaker'; id: string; pos: Vec3 }
+  | { type: 'rotateSpeaker'; id: string; deg?: number; setTo?: number }
+  | { type: 'duplicateSpeaker'; id: string }
   | { type: 'deleteSpeaker'; id: string };
 
 const VERSION = '1';
@@ -65,6 +67,27 @@ function reduce(project: Project, cmd: Command): Project {
         s.id === cmd.id ? { ...s, pos: { ...cmd.pos, y: 0 } } : s
       );
       return { ...project, speakers };
+    }
+    case 'rotateSpeaker': {
+      const speakers = project.speakers.map((s) =>
+        s.id === cmd.id
+          ? { ...s, rotY: cmd.setTo !== undefined ? cmd.setTo : (s.rotY + (cmd.deg || 0)) }
+          : s
+      );
+      return { ...project, speakers };
+    }
+    case 'duplicateSpeaker': {
+      const src = project.speakers.find((s) => s.id === cmd.id);
+      if (src) {
+        const id = uuidv4();
+        const speaker: Speaker = {
+          ...src,
+          id,
+          pos: { ...src.pos, x: src.pos.x + 0.2 },
+        };
+        return { speakers: [...project.speakers, speaker], selectedId: id };
+      }
+      return project;
     }
     case 'deleteSpeaker': {
       const speakers = project.speakers.filter((s) => s.id !== cmd.id);

--- a/src/state/store.js
+++ b/src/state/store.js
@@ -1,0 +1,42 @@
+import { projectStore } from './projectStore';
+
+export function subscribe(fn){
+  return projectStore.subscribe(() => fn(getState()));
+}
+
+export function getState(){
+  const { project } = projectStore.getState();
+  return {
+    selected: project.selectedId ? { type:'speaker', id: project.selectedId } : null,
+    speakers: project.speakers,
+  };
+}
+
+export function dispatch(action){
+  const api = projectStore.getState();
+  switch(action.type){
+    case 'Select':
+      api.dispatch({ type:'selectSpeaker', id: action.payload ? action.payload.id : null });
+      break;
+    case 'Move':
+      if (action.object==='speaker'){
+        api.dispatch({ type:'moveSpeaker', id: action.id, pos: action.pos });
+      }
+      break;
+    case 'RotateY':
+      api.dispatch({ type:'rotateSpeaker', id: action.id, deg: action.deg, setTo: action.setTo });
+      break;
+    case 'Delete':
+      api.dispatch({ type:'deleteSpeaker', id: action.id });
+      break;
+    case 'Duplicate':
+      api.dispatch({ type:'duplicateSpeaker', id: action.id });
+      break;
+    case 'Undo':
+      api.undo();
+      break;
+    case 'Redo':
+      api.redo();
+      break;
+  }
+}

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -51,3 +51,5 @@ body { background:var(--bg); color:var(--fg); margin:0; }
 /* Optional placeholder text style if region empty */
 .region__placeholder { opacity:0.4; font-size:12px; padding:10px; }
 
+.viewer-toolbar button.active { outline:2px solid #4da3ff; }
+

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -4,11 +4,12 @@
   --bg-panel:#151821;
   --fg:#e6e6e6;
   --line:rgba(255,255,255,0.08);
+  --bottom-h: 56px;
 }
 body { background:var(--bg); color:var(--fg); margin:0; }
 #app {
   display:grid;
-  grid-template-rows:56px 1fr var(--bottom-height,56px);        /* header, middle, bottom bar */
+  grid-template-rows:56px 1fr var(--bottom-h,56px);        /* header, middle, bottom bar */
   grid-template-columns:var(--left-width,280px) minmax(0,1fr) var(--right-width,320px);
   grid-template-areas:
     "hdr   hdr   hdr"
@@ -52,4 +53,22 @@ body { background:var(--bg); color:var(--fg); margin:0; }
 .region__placeholder { opacity:0.4; font-size:12px; padding:10px; }
 
 .viewer-toolbar button.active { outline:2px solid #4da3ff; }
+
+/* Bottom splitter overlay */
+.splitter--bottom {
+  grid-area: view;
+  position: relative;
+}
+.splitter--bottom::after {
+  content: "";
+  position: absolute;
+  left: 0; right: 0;
+  bottom: calc(var(--bottom-h, 56px));
+  height: 6px;
+  cursor: ns-resize;
+  z-index: 5;
+  background: linear-gradient(to bottom, transparent 45%, rgba(255,255,255,0.08) 50%, transparent 55%);
+}
+#app.is-fullscreen .splitter--bottom::after { display:none; }
+#panelBottom.is-collapsed + .splitter--bottom::after { display:none; }
 

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -72,3 +72,53 @@ body { background:var(--bg); color:var(--fg); margin:0; }
 #app.is-fullscreen .splitter--bottom::after { display:none; }
 #panelBottom.is-collapsed + .splitter--bottom::after { display:none; }
 
+:root {
+  --left-w: 280px;
+  --right-w: 320px;
+  --bottom-h: 120px;
+  --top-h: 56px;
+}
+#app {
+  grid-template-rows: var(--top-h) 1fr var(--bottom-h);
+  grid-template-columns: var(--left-w) minmax(0,1fr) var(--right-w);
+  grid-template-areas:
+    "hdr   hdr   hdr"
+    "left  view  right"
+    "left  bottom right";
+}
+#appHeader   { grid-area: hdr;   background:var(--bg-panel); border-bottom:1px solid var(--line); display:flex; align-items:center; justify-content:space-between; padding:0 12px; min-height:44px; }
+#panelLeft   { grid-area: left;  background:var(--bg-panel); border-right:1px solid var(--line); min-width:0; overflow:hidden; }
+#panelRight  { grid-area: right; background:var(--bg-panel); border-left:1px solid var(--line); min-width:0; overflow:hidden; }
+#panelBottom { grid-area: bottom;background:var(--bg-panel); border-top:1px solid var(--line); min-height:0; overflow:hidden; }
+#view        { grid-area: view;  position:relative; min-width:0; min-height:0; }
+#view canvas { position:absolute; inset:0; width:100%; height:100%; display:block; z-index:0; }
+.panel__hdr { position:sticky; top:0; height:44px; display:flex; align-items:center; justify-content:space-between; padding:0 10px; border-bottom:1px solid var(--line); background:var(--bg-panel); z-index:1; }
+.panel__title { font-weight:600; font-size:14px; }
+.panel__actions { display:flex; gap:6px; }
+.panel__body { padding:10px; overflow:auto; height:calc(100% - 44px); }
+.panel__collapse, .panel__fs, #btnFullscreen { width:28px; height:28px; border:1px solid var(--line); border-radius:8px; background:transparent; color:var(--fg); cursor:pointer; }
+#panelLeft.is-collapsed   { width:0 !important; min-width:0; border-right:none; }
+#panelRight.is-collapsed  { width:0 !important; min-width:0; border-left:none; }
+#panelBottom.is-collapsed { height:44px; }
+#appHeader.is-collapsed   { height:44px; overflow:hidden; }
+#app.is-fullscreen #panelLeft, #app.is-fullscreen #panelRight, #app.is-fullscreen #panelBottom, #app.is-fullscreen #appHeader { display:none; }
+#app.is-fullscreen { grid-template-rows:0 1fr 0; grid-template-columns:0 1fr 0; }
+#app.fs-left   { grid-template-columns: 1fr 0 0;  grid-template-rows:0 1fr 0; }
+#app.fs-right  { grid-template-columns: 0 0 1fr;  grid-template-rows:0 1fr 0; }
+#app.fs-bottom { grid-template-columns: 0 1fr 0;  grid-template-rows:0 0 1fr; }
+#app.fs-top    { grid-template-columns: 0 1fr 0;  grid-template-rows:1fr 0 0; }
+#app.fs-view   { grid-template-columns: 0 1fr 0;  grid-template-rows:0 1fr 0; }
+#app.fs-left   #panelRight, #app.fs-left   #panelBottom, #app.fs-left   #appHeader, #app.fs-left   #view { display:none; }
+#app.fs-right  #panelLeft,  #app.fs-right  #panelBottom, #app.fs-right  #appHeader, #app.fs-right  #view { display:none; }
+#app.fs-bottom #panelLeft,  #app.fs-bottom #panelRight,  #app.fs-bottom #appHeader, #app.fs-bottom #view { display:none; }
+#app.fs-top    #panelLeft,  #app.fs-top    #panelRight,  #app.fs-top    #panelBottom, #app.fs-top  #view { display:none; }
+#app.fs-view   #panelLeft,  #app.fs-view   #panelRight,  #app.fs-view   #panelBottom, #app.fs-view  #appHeader { display:none; }
+.splitter-v { position:absolute; top:0; bottom:0; width:6px; cursor:ew-resize; z-index:5; }
+.splitter-h { position:absolute; left:0; right:0; height:6px; cursor:ns-resize; z-index:5; }
+#splitLeft  { right:-3px; }
+#splitRight { left:-3px; }
+#splitTop   { bottom:-3px; }
+#splitBottom{ top:-3px; }
+.splitter-v::before, .splitter-h::before { content:""; position:absolute; inset:0; background:linear-gradient(to bottom, transparent 45%, var(--line) 50%, transparent 55%); opacity:.7; }
+.splitter-v::before { transform:rotate(90deg); }
+.is-dragging * { cursor:grabbing !important; user-select:none !important; }

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -2,8 +2,8 @@
 body { background:var(--bg); color:var(--fg); margin:0; }
 #app {
   display:grid;
-  grid-template-rows:56px 1fr 56px;        /* header, middle, bottom bar */
-  grid-template-columns:280px minmax(0,1fr) 320px;
+  grid-template-rows:56px 1fr var(--bottom-height,56px);        /* header, middle, bottom bar */
+  grid-template-columns:var(--left-width,280px) minmax(0,1fr) var(--right-width,320px);
   grid-template-areas:
     "hdr   hdr   hdr"
     "left  view  right"
@@ -12,9 +12,9 @@ body { background:var(--bg); color:var(--fg); margin:0; }
 }
 #appHeader   { grid-area:hdr;   display:flex; align-items:center; justify-content:space-between;
   padding:0 12px; background:var(--bg-panel); border-bottom:1px solid var(--line); }
-#panelLeft   { grid-area:left;   background:var(--bg-panel); border-right:1px solid var(--line); min-width:0; overflow:hidden; }
-#panelRight  { grid-area:right;  background:var(--bg-panel); border-left:1px solid var(--line); min-width:0; overflow:hidden; }
-#panelBottom { grid-area:bottom; background:var(--bg-panel); border-top:1px solid var(--line); min-height:0; overflow:hidden; }
+#panelLeft   { grid-area:left;   background:var(--bg-panel); border-right:1px solid var(--line); min-width:0; overflow:hidden; position:relative; }
+#panelRight  { grid-area:right;  background:var(--bg-panel); border-left:1px solid var(--line); min-width:0; overflow:hidden; position:relative; }
+#panelBottom { grid-area:bottom; background:var(--bg-panel); border-top:1px solid var(--line); min-height:0; overflow:hidden; position:relative; }
 #view        { grid-area:view;   position:relative; min-width:0; min-height:0; }
 #view canvas { position:absolute; inset:0; width:100%; height:100%; display:block; z-index:0; }
 
@@ -30,6 +30,13 @@ body { background:var(--bg); color:var(--fg); margin:0; }
 #panelLeft.is-collapsed   .panel__toggle::before { transform:rotate(-90deg); }
 #panelRight.is-collapsed  .panel__toggle::before { transform:rotate(90deg); }
 #panelBottom.is-collapsed .panel__toggle::before { transform:rotate(180deg); }
+
+/* Resize handles */
+.panel__resizer { position:absolute; background:var(--line); opacity:0; transition:opacity .2s; }
+#panelLeft:hover  .panel__resizer,#panelRight:hover .panel__resizer,#panelBottom:hover .panel__resizer{opacity:1;}
+#panelLeft .panel__resizer  { top:0; right:0; width:4px; height:100%; cursor:col-resize; }
+#panelRight .panel__resizer { top:0; left:0;  width:4px; height:100%; cursor:col-resize; }
+#panelBottom .panel__resizer{ top:0; left:0;  width:100%; height:4px; cursor:row-resize; }
 
 /* Fullscreen hides side/bottom panels, expands center */
 #app.is-fullscreen #panelLeft, #app.is-fullscreen #panelRight, #app.is-fullscreen #panelBottom { display:none; }

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -115,10 +115,20 @@ body { background:var(--bg); color:var(--fg); margin:0; }
 #app.fs-view   #panelLeft,  #app.fs-view   #panelRight,  #app.fs-view   #panelBottom, #app.fs-view  #appHeader { display:none; }
 .splitter-v { position:absolute; top:0; bottom:0; width:6px; cursor:ew-resize; z-index:5; }
 .splitter-h { position:absolute; left:0; right:0; height:6px; cursor:ns-resize; z-index:5; }
-#splitLeft  { right:-3px; }
-#splitRight { left:-3px; }
-#splitTop   { bottom:-3px; }
-#splitBottom{ top:-3px; }
+#splitLeft  { left:-3px; }
+#splitRight { right:-3px; }
+#splitTop   { top:-3px; }
+#splitBottom{ bottom:-3px; }
 .splitter-v::before, .splitter-h::before { content:""; position:absolute; inset:0; background:linear-gradient(to bottom, transparent 45%, var(--line) 50%, transparent 55%); opacity:.7; }
 .splitter-v::before { transform:rotate(90deg); }
 .is-dragging * { cursor:grabbing !important; user-select:none !important; }
+
+#fsExitPill {
+  position: fixed; top: 12px; right: 12px;
+  background: rgba(20,22,28,.9);
+  color: var(--fg, #e6e6e6);
+  border: 1px solid var(--line, rgba(255,255,255,0.08));
+  border-radius: 999px; padding: 8px 12px; z-index: 9999;
+  font-size: 12px; backdrop-filter: blur(4px); cursor: pointer;
+}
+#fsExitPill.hidden { display: none; }

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -1,30 +1,40 @@
 :root { --bg:#0f1115; --bg-panel:#151821; --fg:#e6e6e6; --line:rgba(255,255,255,0.08); }
-body { background:var(--bg); color:var(--fg); }
+body { background:var(--bg); color:var(--fg); margin:0; }
 #app {
   display:grid;
-  grid-template-rows:56px 1fr;
+  grid-template-rows:56px 1fr 56px;        /* header, middle, bottom bar */
   grid-template-columns:280px minmax(0,1fr) 320px;
   grid-template-areas:
-    "hdr hdr hdr"
-    "left view right";
+    "hdr   hdr   hdr"
+    "left  view  right"
+    "left  bottom right";
   height:100vh; width:100vw; overflow:hidden;
 }
-#appHeader { grid-area:hdr; display:flex; align-items:center; justify-content:space-between;
-  padding:0 12px; background:var(--bg-panel); border-bottom:1px solid var(--line);
-}
-#panelLeft  { grid-area:left;  background:var(--bg-panel); border-right:1px solid var(--line); min-width:0; overflow:hidden; }
-#panelRight { grid-area:right; background:var(--bg-panel); border-left:1px solid var(--line); min-width:0; overflow:hidden; }
-#view { grid-area:view; position:relative; min-width:0; }
-#view canvas { position:absolute; inset:0; width:100%; height:100%; z-index:0; display:block; }
-.panel__hdr { position:sticky; top:0; height:44px; display:flex; align-items:center; justify-content:space-between;
-  padding:0 10px; border-bottom:1px solid var(--line); background:var(--bg-panel); z-index:1;
-}
-.panel__toggle, #btnFullscreen {
-  width:28px; height:28px; border:1px solid var(--line); border-radius:8px;
-  background:transparent; color:var(--fg); cursor:pointer;
+#appHeader   { grid-area:hdr;   display:flex; align-items:center; justify-content:space-between;
+  padding:0 12px; background:var(--bg-panel); border-bottom:1px solid var(--line); }
+#panelLeft   { grid-area:left;   background:var(--bg-panel); border-right:1px solid var(--line); min-width:0; overflow:hidden; }
+#panelRight  { grid-area:right;  background:var(--bg-panel); border-left:1px solid var(--line); min-width:0; overflow:hidden; }
+#panelBottom { grid-area:bottom; background:var(--bg-panel); border-top:1px solid var(--line); min-height:0; overflow:hidden; }
+#view        { grid-area:view;   position:relative; min-width:0; min-height:0; }
+#view canvas { position:absolute; inset:0; width:100%; height:100%; display:block; z-index:0; }
+
+/* Panel chrome */
+.panel__hdr  { position:sticky; top:0; height:44px; display:flex; align-items:center; justify-content:space-between;
+  padding:0 10px; border-bottom:1px solid var(--line); background:var(--bg-panel); z-index:1; }
+.panel__title { font-weight:600; font-size:14px; }
+.panel__body { padding:10px; overflow:auto; height:calc(100% - 44px); }
+.icon-btn, .panel__toggle {
+  width:28px; height:28px; border:1px solid var(--line); border-radius:8px; background:transparent; color:var(--fg); cursor:pointer;
 }
 .panel__toggle::before { content:"▾"; display:block; text-align:center; transform:rotate(0deg); }
-#panelLeft.is-collapsed  .panel__toggle::before { transform:rotate(-90deg); }
-#panelRight.is-collapsed .panel__toggle::before { transform:rotate(90deg); }
-#app.is-fullscreen #panelLeft, #app.is-fullscreen #panelRight { display:none; }
-#app.is-fullscreen { grid-template-columns:0 minmax(0,1fr) 0; }
+#panelLeft.is-collapsed   .panel__toggle::before { transform:rotate(-90deg); }
+#panelRight.is-collapsed  .panel__toggle::before { transform:rotate(90deg); }
+#panelBottom.is-collapsed .panel__toggle::before { transform:rotate(180deg); }
+
+/* Fullscreen hides side/bottom panels, expands center */
+#app.is-fullscreen #panelLeft, #app.is-fullscreen #panelRight, #app.is-fullscreen #panelBottom { display:none; }
+#app.is-fullscreen { grid-template-rows:56px 1fr 0; grid-template-columns:0 minmax(0,1fr) 0; }
+
+/* Optional placeholder text style if region empty */
+.region__placeholder { opacity:0.4; font-size:12px; padding:10px; }
+

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -1,0 +1,30 @@
+:root { --bg:#0f1115; --bg-panel:#151821; --fg:#e6e6e6; --line:rgba(255,255,255,0.08); }
+body { background:var(--bg); color:var(--fg); }
+#app {
+  display:grid;
+  grid-template-rows:56px 1fr;
+  grid-template-columns:280px minmax(0,1fr) 320px;
+  grid-template-areas:
+    "hdr hdr hdr"
+    "left view right";
+  height:100vh; width:100vw; overflow:hidden;
+}
+#appHeader { grid-area:hdr; display:flex; align-items:center; justify-content:space-between;
+  padding:0 12px; background:var(--bg-panel); border-bottom:1px solid var(--line);
+}
+#panelLeft  { grid-area:left;  background:var(--bg-panel); border-right:1px solid var(--line); min-width:0; overflow:hidden; }
+#panelRight { grid-area:right; background:var(--bg-panel); border-left:1px solid var(--line); min-width:0; overflow:hidden; }
+#view { grid-area:view; position:relative; min-width:0; }
+#view canvas { position:absolute; inset:0; width:100%; height:100%; z-index:0; display:block; }
+.panel__hdr { position:sticky; top:0; height:44px; display:flex; align-items:center; justify-content:space-between;
+  padding:0 10px; border-bottom:1px solid var(--line); background:var(--bg-panel); z-index:1;
+}
+.panel__toggle, #btnFullscreen {
+  width:28px; height:28px; border:1px solid var(--line); border-radius:8px;
+  background:transparent; color:var(--fg); cursor:pointer;
+}
+.panel__toggle::before { content:"▾"; display:block; text-align:center; transform:rotate(0deg); }
+#panelLeft.is-collapsed  .panel__toggle::before { transform:rotate(-90deg); }
+#panelRight.is-collapsed .panel__toggle::before { transform:rotate(90deg); }
+#app.is-fullscreen #panelLeft, #app.is-fullscreen #panelRight { display:none; }
+#app.is-fullscreen { grid-template-columns:0 minmax(0,1fr) 0; }

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -1,4 +1,10 @@
-:root { --bg:#0f1115; --bg-panel:#151821; --fg:#e6e6e6; --line:rgba(255,255,255,0.08); }
+:root {
+  color-scheme: dark;
+  --bg:#0f1115;
+  --bg-panel:#151821;
+  --fg:#e6e6e6;
+  --line:rgba(255,255,255,0.08);
+}
 body { background:var(--bg); color:var(--fg); margin:0; }
 #app {
   display:grid;

--- a/src/three/controls/objectControls.js
+++ b/src/three/controls/objectControls.js
@@ -1,0 +1,142 @@
+import * as THREE from 'three';
+import { TransformControls } from 'three/examples/jsm/controls/TransformControls.js';
+import { subscribe, dispatch } from '../../state/store.js';
+
+let scene, camera, renderer, orbit, control, raycaster, dom;
+let snapEnabled = true, snapSize = 0.0762; // meters
+const selectable = new Set();   // meshes/groups we can select (speakers, mlp, etc.)
+let selected = null;
+
+export function registerSelectable(obj){
+  selectable.add(obj);
+}
+export function unregisterSelectable(obj){
+  selectable.delete(obj);
+  if (selected === obj) deselect();
+}
+
+export function initObjectControls(ctx){
+  ({ scene, camera, controls:orbit, renderer } = ctx);
+  dom = renderer.domElement;
+  raycaster = new THREE.Raycaster();
+
+  control = new TransformControls(camera, dom);
+  control.setSpace('world');
+  control.addEventListener('dragging-changed', e => { orbit.enabled = !e.value; });
+  control.addEventListener('mouseDown', ()=>{ applySnap(); });
+  control.addEventListener('objectChange', ()=> {
+    if (!selected) return;
+    // commit move/rotate in mouseUp
+  });
+  control.addEventListener('mouseUp', ()=> {
+    if (!selected) return;
+    const pos = selected.position;
+    if (control.getMode()==='translate'){
+      dispatch({ type:'Move', object:selected.userData?.kind || 'speaker', id:selected.userData?.id, pos:{ x:pos.x, y:pos.y, z:pos.z } });
+    }
+    if (control.getMode()==='rotate'){
+      const deg = THREE.MathUtils.radToDeg(selected.rotation.y);
+      dispatch({ type:'RotateY', id:selected.userData?.id, setTo:deg });
+    }
+  });
+  scene.add(control);
+
+  // Selection by click
+  dom.addEventListener('pointerdown', onPointerDown);
+
+  // React to store changes (selection created/deleted)
+  subscribe(state => {
+    if (state.selected){
+      const obj = findById(state.selected);
+      if (obj) select(obj); else deselect();
+    } else {
+      deselect();
+    }
+  });
+
+  return {
+    setModeSelect(){ control.detach(); markActive('toolSelect'); },
+    setModeTranslate(){ control.setMode('translate'); markActive('toolTranslate'); },
+    setModeRotate(){ control.setMode('rotate'); markActive('toolRotate'); },
+    duplicateSelected(){ if(!selected) return; duplicateObject(selected); },
+    deleteSelected(){ if(!selected) return; deleteObject(selected); },
+    setSnapEnabled(v){ snapEnabled = v; applySnap(); },
+    setSnapSize(v){ snapSize = Math.max(0, v||0); applySnap(); },
+  };
+}
+
+function onPointerDown(e){
+  const rect = dom.getBoundingClientRect();
+  const ndc = new THREE.Vector2(
+    ((e.clientX - rect.left)/rect.width)*2 - 1,
+    -((e.clientY - rect.top)/rect.height)*2 + 1
+  );
+  raycaster.setFromCamera(ndc, camera);
+  const hits = raycaster.intersectObjects([...selectable], true);
+  if (hits.length){
+    const root = getRootRegistered(hits[0].object);
+    if (root) {
+      dispatch({ type:'Select', payload:{ type: root.userData?.kind || 'speaker', id: root.userData?.id }});
+      select(root);
+    }
+  } else {
+    dispatch({ type:'Select', payload:null });
+    deselect();
+  }
+}
+
+function getRootRegistered(obj){
+  let p = obj;
+  while (p && p.parent){ if (selectable.has(p)) return p; p = p.parent; }
+  return selectable.has(obj) ? obj : null;
+}
+
+function select(obj){
+  selected = obj;
+  control.attach(obj);
+  applySnap();
+  markActive(null);
+}
+function deselect(){
+  selected = null;
+  control.detach();
+  markActive('toolSelect');
+}
+
+function applySnap(){
+  if (!control) return;
+  if (snapEnabled){
+    control.setTranslationSnap(snapSize);
+    control.setRotationSnap(THREE.MathUtils.degToRad(5));
+  } else {
+    control.setTranslationSnap(null);
+    control.setRotationSnap(null);
+  }
+}
+
+function duplicateObject(src){
+  const clone = src.clone(true);
+  clone.position.x += snapSize || 0.1;
+  src.parent.add(clone);
+  dispatch({ type:'Duplicate', id: src.userData?.id });
+}
+
+function deleteObject(obj){
+  dispatch({ type:'Delete', typeOf: obj.userData?.kind || 'speaker', id: obj.userData?.id });
+  obj.parent?.remove(obj);
+  deselect();
+}
+
+function findById(sel){
+  let found = null;
+  scene.traverse(o=>{
+    if (o.userData && o.userData.id===sel.id && (sel.type===o.userData.kind)) found = o;
+  });
+  return found;
+}
+
+function markActive(id){
+  ['toolSelect','toolTranslate','toolRotate'].forEach(x=>{
+    const b = document.getElementById(x); if (b) b.classList.toggle('active', x===id);
+  });
+}

--- a/src/three/objects/SpeakerMesh.ts
+++ b/src/three/objects/SpeakerMesh.ts
@@ -9,6 +9,7 @@ export function createSpeakerMesh(data: Speaker): SpeakerMesh {
   const mesh = new THREE.Mesh(geom, mat) as SpeakerMesh;
   mesh.position.set(data.pos.x, data.pos.y, data.pos.z);
   mesh.rotation.y = data.rotY;
+  mesh.userData = { id: data.id, kind: 'speaker' };
 
   const edges = new THREE.LineSegments(
     new THREE.EdgesGeometry(geom),

--- a/src/ui/layout-enforce.js
+++ b/src/ui/layout-enforce.js
@@ -61,7 +61,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const header = ensurePanel('appHeader','Navigation');
   const left   = ensurePanel('panelLeft','Controls');
   const right  = ensurePanel('panelRight','Equipment');
-  const bottom = ensurePanel('panelBottom','Viewer Controls');
+  const bottom = ensurePanel('panelBottom','Tools & Controls');
 
   // If previous runs put “Controls” content in the right panel, move those nodes to left body.
   function moveChildrenIfLabeled(srcBody, dstBody, keywords) {
@@ -77,8 +77,16 @@ document.addEventListener('DOMContentLoaded', () => {
   const bottomBody = document.getElementById('panelBottomBody');
 
   // Heuristic re-homing:
-  // Anything with “speaker”, “mlp”, “controls”, “measure”, “snap”, “camera” -> LEFT or BOTTOM depending on type
-  moveChildrenIfLabeled(rightBody, leftBody, ['controls','speaker','mlp','measure','snap','camera']);
+  // Anything with “controls”, “mlp”, “measure”, “snap”, “camera” -> LEFT
+  moveChildrenIfLabeled(rightBody, leftBody, ['controls','mlp','measure','snap','camera']);
+  // Move primary UI container to bottom bar if present
+  const ui = document.getElementById('ui');
+  if (ui && bottomBody && ui.parentElement !== bottomBody) bottomBody.appendChild(ui);
+  // Relocate equipment panel from UI container to right bar
+  if (ui && rightBody) {
+    const eqHeader = [...ui.querySelectorAll('h2')].find(h=>/equipment/i.test(h.textContent));
+    if (eqHeader) rightBody.appendChild(eqHeader.parentElement);
+  }
   // If there is an existing viewer toolbar (by role or class), move to bottom
   const toolbar = document.querySelector('[data-role="viewer-toolbar"], .viewer-toolbar, #viewerToolbar');
   if (toolbar && bottomBody) bottomBody.appendChild(toolbar);

--- a/src/ui/layout-enforce.js
+++ b/src/ui/layout-enforce.js
@@ -93,7 +93,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   // State persistence (left/bottom/right collapse + fullscreen)
   const KEY_L='ui.leftCollapsed', KEY_B='ui.bottomCollapsed', KEY_R='ui.rightCollapsed', KEY_F='ui.fullscreen';
-  const KEY_LW='ui.leftWidth', KEY_RW='ui.rightWidth', KEY_BH='ui.bottomHeight';
+  const KEY_LW='ui.leftWidth', KEY_RW='ui.rightWidth';
   const state = {
     leftCollapsed:   localStorage.getItem(KEY_L) === 'true',
     bottomCollapsed: localStorage.getItem(KEY_B) === 'true',
@@ -102,10 +102,8 @@ document.addEventListener('DOMContentLoaded', () => {
   };
   const storedLW = parseInt(localStorage.getItem(KEY_LW),10);
   const storedRW = parseInt(localStorage.getItem(KEY_RW),10);
-  const storedBH = parseInt(localStorage.getItem(KEY_BH),10);
   if (!isNaN(storedLW)) app.style.setProperty('--left-width', storedLW + 'px');
   if (!isNaN(storedRW)) app.style.setProperty('--right-width', storedRW + 'px');
-  if (!isNaN(storedBH)) app.style.setProperty('--bottom-height', storedBH + 'px');
   const apply = ()=>{
     left.classList.toggle('is-collapsed',   state.leftCollapsed);
     bottom.classList.toggle('is-collapsed', state.bottomCollapsed);
@@ -137,43 +135,30 @@ document.addEventListener('DOMContentLoaded', () => {
     const res = panel.querySelector('.panel__resizer') || document.createElement('div');
     res.className = 'panel__resizer';
     if (!res.parentElement) panel.appendChild(res);
-    let startX,startY,startW,startH;
+    let startX,startW;
     const onMove = (e)=>{
-      if (side==='left' || side==='right'){
-        const dx = e.clientX - startX;
-        let w = side==='left'?startW+dx:startW-dx;
-        w = Math.max(150,w);
-        app.style.setProperty(side==='left'?'--left-width':'--right-width', w+'px');
-      } else if (side==='bottom'){
-        const dy = startY - e.clientY;
-        let h = startH+dy;
-        h = Math.max(44,h);
-        app.style.setProperty('--bottom-height', h+'px');
-      }
+      const dx = e.clientX - startX;
+      let w = side==='left'?startW+dx:startW-dx;
+      w = Math.max(150,w);
+      app.style.setProperty(side==='left'?'--left-width':'--right-width', w+'px');
     };
     const onUp = ()=>{
       window.removeEventListener('mousemove', onMove);
       window.removeEventListener('mouseup', onUp);
-      if (side==='left'||side==='right'){
-        const val = parseInt(getComputedStyle(app).getPropertyValue(side==='left'?'--left-width':'--right-width'),10);
-        localStorage.setItem(side==='left'?KEY_LW:KEY_RW, String(val));
-      } else if (side==='bottom'){
-        const val = parseInt(getComputedStyle(app).getPropertyValue('--bottom-height'),10);
-        localStorage.setItem(KEY_BH, String(val));
-      }
+      const val = parseInt(getComputedStyle(app).getPropertyValue(side==='left'?'--left-width':'--right-width'),10);
+      localStorage.setItem(side==='left'?KEY_LW:KEY_RW, String(val));
     };
     res.addEventListener('mousedown',(e)=>{
       e.preventDefault();
-      startX = e.clientX; startY = e.clientY;
+      startX = e.clientX;
       const rect = panel.getBoundingClientRect();
-      startW = rect.width; startH = rect.height;
+      startW = rect.width;
       window.addEventListener('mousemove', onMove);
       window.addEventListener('mouseup', onUp);
     });
   }
   makeResizable(left,'left');
   makeResizable(right,'right');
-  makeResizable(bottom,'bottom');
 
   console.info('[layout] 5-region layout enforced non-destructively.');
 });

--- a/src/ui/layout-enforce.js
+++ b/src/ui/layout-enforce.js
@@ -85,12 +85,19 @@ document.addEventListener('DOMContentLoaded', () => {
 
   // State persistence (left/bottom/right collapse + fullscreen)
   const KEY_L='ui.leftCollapsed', KEY_B='ui.bottomCollapsed', KEY_R='ui.rightCollapsed', KEY_F='ui.fullscreen';
+  const KEY_LW='ui.leftWidth', KEY_RW='ui.rightWidth', KEY_BH='ui.bottomHeight';
   const state = {
     leftCollapsed:   localStorage.getItem(KEY_L) === 'true',
     bottomCollapsed: localStorage.getItem(KEY_B) === 'true',
     rightCollapsed:  localStorage.getItem(KEY_R) === 'true',
     fullscreen:      localStorage.getItem(KEY_F) === 'true',
   };
+  const storedLW = parseInt(localStorage.getItem(KEY_LW),10);
+  const storedRW = parseInt(localStorage.getItem(KEY_RW),10);
+  const storedBH = parseInt(localStorage.getItem(KEY_BH),10);
+  if (!isNaN(storedLW)) app.style.setProperty('--left-width', storedLW + 'px');
+  if (!isNaN(storedRW)) app.style.setProperty('--right-width', storedRW + 'px');
+  if (!isNaN(storedBH)) app.style.setProperty('--bottom-height', storedBH + 'px');
   const apply = ()=>{
     left.classList.toggle('is-collapsed',   state.leftCollapsed);
     bottom.classList.toggle('is-collapsed', state.bottomCollapsed);
@@ -116,6 +123,49 @@ document.addEventListener('DOMContentLoaded', () => {
   });
   const btnFS = document.getElementById('btnFullscreen');
   btnFS && btnFS.addEventListener('click', ()=>{ state.fullscreen = !state.fullscreen; apply(); save(); });
+
+  // Resizable panels
+  function makeResizable(panel, side) {
+    const res = panel.querySelector('.panel__resizer') || document.createElement('div');
+    res.className = 'panel__resizer';
+    if (!res.parentElement) panel.appendChild(res);
+    let startX,startY,startW,startH;
+    const onMove = (e)=>{
+      if (side==='left' || side==='right'){
+        const dx = e.clientX - startX;
+        let w = side==='left'?startW+dx:startW-dx;
+        w = Math.max(150,w);
+        app.style.setProperty(side==='left'?'--left-width':'--right-width', w+'px');
+      } else if (side==='bottom'){
+        const dy = startY - e.clientY;
+        let h = startH+dy;
+        h = Math.max(44,h);
+        app.style.setProperty('--bottom-height', h+'px');
+      }
+    };
+    const onUp = ()=>{
+      window.removeEventListener('mousemove', onMove);
+      window.removeEventListener('mouseup', onUp);
+      if (side==='left'||side==='right'){
+        const val = parseInt(getComputedStyle(app).getPropertyValue(side==='left'?'--left-width':'--right-width'),10);
+        localStorage.setItem(side==='left'?KEY_LW:KEY_RW, String(val));
+      } else if (side==='bottom'){
+        const val = parseInt(getComputedStyle(app).getPropertyValue('--bottom-height'),10);
+        localStorage.setItem(KEY_BH, String(val));
+      }
+    };
+    res.addEventListener('mousedown',(e)=>{
+      e.preventDefault();
+      startX = e.clientX; startY = e.clientY;
+      const rect = panel.getBoundingClientRect();
+      startW = rect.width; startH = rect.height;
+      window.addEventListener('mousemove', onMove);
+      window.addEventListener('mouseup', onUp);
+    });
+  }
+  makeResizable(left,'left');
+  makeResizable(right,'right');
+  makeResizable(bottom,'bottom');
 
   console.info('[layout] 5-region layout enforced non-destructively.');
 });

--- a/src/ui/layout-enforce.js
+++ b/src/ui/layout-enforce.js
@@ -91,14 +91,13 @@ document.addEventListener('DOMContentLoaded', () => {
   const toolbar = document.querySelector('[data-role="viewer-toolbar"], .viewer-toolbar, #viewerToolbar');
   if (toolbar && bottomBody) bottomBody.appendChild(toolbar);
 
-  // State persistence (left/bottom/right collapse + fullscreen)
-  const KEY_L='ui.leftCollapsed', KEY_B='ui.bottomCollapsed', KEY_R='ui.rightCollapsed', KEY_F='ui.fullscreen';
+  // State persistence (left/bottom/right collapse)
+  const KEY_L='ui.leftCollapsed', KEY_B='ui.bottomCollapsed', KEY_R='ui.rightCollapsed';
   const KEY_LW='ui.leftWidth', KEY_RW='ui.rightWidth';
   const state = {
     leftCollapsed:   localStorage.getItem(KEY_L) === 'true',
     bottomCollapsed: localStorage.getItem(KEY_B) === 'true',
     rightCollapsed:  localStorage.getItem(KEY_R) === 'true',
-    fullscreen:      localStorage.getItem(KEY_F) === 'true',
   };
   const storedLW = parseInt(localStorage.getItem(KEY_LW),10);
   const storedRW = parseInt(localStorage.getItem(KEY_RW),10);
@@ -108,13 +107,11 @@ document.addEventListener('DOMContentLoaded', () => {
     left.classList.toggle('is-collapsed',   state.leftCollapsed);
     bottom.classList.toggle('is-collapsed', state.bottomCollapsed);
     right.classList.toggle('is-collapsed',  state.rightCollapsed);
-    app.classList.toggle('is-fullscreen',   state.fullscreen);
   };
   const save = ()=>{
     localStorage.setItem(KEY_L, String(state.leftCollapsed));
     localStorage.setItem(KEY_B, String(state.bottomCollapsed));
     localStorage.setItem(KEY_R, String(state.rightCollapsed));
-    localStorage.setItem(KEY_F, String(state.fullscreen));
   };
   apply();
 
@@ -127,8 +124,6 @@ document.addEventListener('DOMContentLoaded', () => {
     const m = { panelLeft:'leftCollapsed', panelBottom:'bottomCollapsed', panelRight:'rightCollapsed' }[id];
     if (m) { state[m] = !state[m]; apply(); save(); }
   });
-  const btnFS = document.getElementById('btnFullscreen');
-  btnFS && btnFS.addEventListener('click', ()=>{ state.fullscreen = !state.fullscreen; apply(); save(); });
 
   // Resizable panels
   function makeResizable(panel, side) {

--- a/src/ui/layout-enforce.js
+++ b/src/ui/layout-enforce.js
@@ -1,0 +1,122 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const $  = (s)=>document.querySelector(s);
+  const $$ = (s)=>[...document.querySelectorAll(s)];
+
+  // Require #view (the viewer). If missing, bail (don’t rebuild viewer).
+  const view = $('#view');
+  if (!view) { console.warn('[layout] #view missing; aborting non-destructive layout.'); return; }
+
+  // Ensure #app root exists and contains #view (non-destructive)
+  let app = $('#app');
+  if (!app) {
+    app = document.createElement('div'); app.id='app';
+    // Place at body start and then move existing nodes into it, preserving #view parentage
+    document.body.prepend(app);
+  }
+  if (view.parentElement !== app) app.appendChild(view);
+
+  // Helper to ensure a panel exists with hdr/title/toggle/body
+  function ensurePanel(id, title) {
+    let el = document.getElementById(id);
+    if (!el) {
+      el = document.createElement(id === 'appHeader' ? 'header' : (id === 'panelBottom' ? 'section' : 'aside'));
+      el.id = id;
+      if (id === 'appHeader') {
+        el.innerHTML = `<div class="panel__title">${title}</div><button id="btnFullscreen" class="icon-btn" title="Fullscreen" aria-label="Fullscreen">⤢</button>`;
+        app.prepend(el);
+      } else {
+        el.innerHTML = `
+          <div class="panel__hdr">
+            <div class="panel__title">${title}</div>
+            <button class="panel__toggle" data-target="${id}" aria-label="Collapse/Expand"></button>
+          </div>
+          <div class="panel__body" id="${id}Body"><div class="region__placeholder">${title}</div></div>`;
+        // Insert in correct grid order
+        if (id === 'panelLeft')  app.insertBefore(el, view);
+        else if (id === 'panelRight') app.appendChild(el);
+        else if (id === 'panelBottom') app.appendChild(el);
+      }
+    } else {
+      // If structure exists but missing chrome, patch minimal chrome
+      if (id !== 'appHeader' && !el.querySelector('.panel__hdr')) {
+        el.insertAdjacentHTML('afterbegin',
+          `<div class="panel__hdr">
+             <div class="panel__title">${title}</div>
+             <button class="panel__toggle" data-target="${id}" aria-label="Collapse/Expand"></button>
+           </div>`);
+      }
+      if (id !== 'appHeader' && !document.getElementById(id+'Body')) {
+        const body = document.createElement('div'); body.className='panel__body'; body.id=id+'Body';
+        el.appendChild(body);
+      }
+      if (id === 'appHeader' && !document.getElementById('btnFullscreen')) {
+        const fs = document.createElement('button'); fs.id='btnFullscreen'; fs.className='icon-btn'; fs.title='Fullscreen'; fs.ariaLabel='Fullscreen'; fs.textContent='⤢';
+        el.appendChild(fs);
+      }
+    }
+    return el;
+  }
+
+  // Ensure all regions
+  const header = ensurePanel('appHeader','Navigation');
+  const left   = ensurePanel('panelLeft','Controls');
+  const right  = ensurePanel('panelRight','Equipment');
+  const bottom = ensurePanel('panelBottom','Viewer Controls');
+
+  // If previous runs put “Controls” content in the right panel, move those nodes to left body.
+  function moveChildrenIfLabeled(srcBody, dstBody, keywords) {
+    if (!srcBody || !dstBody) return;
+    const nodes = [...srcBody.children];
+    nodes.forEach(n=>{
+      const text = (n.textContent||'').toLowerCase();
+      if (keywords.some(k=>text.includes(k))) dstBody.appendChild(n);
+    });
+  }
+  const leftBody   = document.getElementById('panelLeftBody');
+  const rightBody  = document.getElementById('panelRightBody');
+  const bottomBody = document.getElementById('panelBottomBody');
+
+  // Heuristic re-homing:
+  // Anything with “speaker”, “mlp”, “controls”, “measure”, “snap”, “camera” -> LEFT or BOTTOM depending on type
+  moveChildrenIfLabeled(rightBody, leftBody, ['controls','speaker','mlp','measure','snap','camera']);
+  // If there is an existing viewer toolbar (by role or class), move to bottom
+  const toolbar = document.querySelector('[data-role="viewer-toolbar"], .viewer-toolbar, #viewerToolbar');
+  if (toolbar && bottomBody) bottomBody.appendChild(toolbar);
+
+  // State persistence (left/bottom/right collapse + fullscreen)
+  const KEY_L='ui.leftCollapsed', KEY_B='ui.bottomCollapsed', KEY_R='ui.rightCollapsed', KEY_F='ui.fullscreen';
+  const state = {
+    leftCollapsed:   localStorage.getItem(KEY_L) === 'true',
+    bottomCollapsed: localStorage.getItem(KEY_B) === 'true',
+    rightCollapsed:  localStorage.getItem(KEY_R) === 'true',
+    fullscreen:      localStorage.getItem(KEY_F) === 'true',
+  };
+  const apply = ()=>{
+    left.classList.toggle('is-collapsed',   state.leftCollapsed);
+    bottom.classList.toggle('is-collapsed', state.bottomCollapsed);
+    right.classList.toggle('is-collapsed',  state.rightCollapsed);
+    app.classList.toggle('is-fullscreen',   state.fullscreen);
+  };
+  const save = ()=>{
+    localStorage.setItem(KEY_L, String(state.leftCollapsed));
+    localStorage.setItem(KEY_B, String(state.bottomCollapsed));
+    localStorage.setItem(KEY_R, String(state.rightCollapsed));
+    localStorage.setItem(KEY_F, String(state.fullscreen));
+  };
+  apply();
+
+  // Toggle handlers (no other wiring)
+  app.addEventListener('click', (e)=>{
+    const t = e.target.closest('.panel__toggle');
+    if (!t) return;
+    const id = t.getAttribute('data-target');
+    if (!id) return;
+    const m = { panelLeft:'leftCollapsed', panelBottom:'bottomCollapsed', panelRight:'rightCollapsed' }[id];
+    if (m) { state[m] = !state[m]; apply(); save(); }
+  });
+  const btnFS = document.getElementById('btnFullscreen');
+  btnFS && btnFS.addEventListener('click', ()=>{ state.fullscreen = !state.fullscreen; apply(); save(); });
+
+  console.info('[layout] 5-region layout enforced non-destructively.');
+});
+

--- a/src/ui/layout.js
+++ b/src/ui/layout.js
@@ -1,0 +1,110 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const $ = (s)=>document.querySelector(s);
+
+  // Require existing viewer region; if missing, warn & bail (DO NOT rebuild viewer).
+  const view = $('#view');
+  if (!view) { console.warn('[layout] #view not found; skipping layout enhancement.'); return; }
+
+  // Ensure #app root exists or make a lightweight wrapper without reparenting existing canvas.
+  let app = $('#app');
+  if (!app) {
+    app = document.createElement('div');
+    app.id = 'app';
+    // Wrap current body children safely:
+    // Insert at body start and move only NON-viewer siblings into it carefully
+    document.body.prepend(app);
+    // Move everything except #view into #app, but never move canvas or change #view parent.
+    [...document.body.children].forEach(el=>{
+      if (el === app || el === view) return;
+      app.appendChild(el);
+    });
+    app.appendChild(view); // if not already inside app, append (this preserves canvas if already a child)
+  }
+
+  // Header
+  let header = $('#appHeader');
+  if (!header) {
+    header = document.createElement('header');
+    header.id = 'appHeader';
+    header.innerHTML = `
+      <div class="hdr__title">Navigation</div>
+      <button id="btnFullscreen" title="Fullscreen" aria-label="Fullscreen"></button>
+    `;
+    app.prepend(header);
+  }
+
+  // Left panel
+  let left = $('#panelLeft');
+  if (!left) {
+    left = document.createElement('aside');
+    left.id = 'panelLeft';
+    left.innerHTML = `
+      <div class="panel__hdr">
+        <div class="panel__title">Controls</div>
+        <button class="panel__toggle" data-target="panelLeft" aria-label="Collapse/Expand"></button>
+      </div>
+      <div class="panel__body" id="panelLeftBody"></div>
+    `;
+    // Insert before #view to satisfy grid flow
+    app.insertBefore(left, view);
+  }
+
+  // Right panel
+  let right = $('#panelRight');
+  if (!right) {
+    right = document.createElement('aside');
+    right.id = 'panelRight';
+    right.innerHTML = `
+      <div class="panel__hdr">
+        <div class="panel__title">Equipment</div>
+        <button class="panel__toggle" data-target="panelRight" aria-label="Collapse/Expand"></button>
+      </div>
+      <div class="panel__body" id="panelRightBody"></div>
+    `;
+    // Insert after #view
+    if (view.nextSibling) view.parentNode.insertBefore(right, view.nextSibling);
+    else view.parentNode.appendChild(right);
+  }
+
+  // Move existing #ui (if any) into left panel body
+  const oldUI = $('#ui');
+  const leftBody = $('#panelLeftBody');
+  if (oldUI && leftBody && !leftBody.contains(oldUI)) {
+    leftBody.appendChild(oldUI);
+  }
+
+  // State
+  const KEY_L='ui.leftCollapsed', KEY_R='ui.rightCollapsed', KEY_F='ui.fullscreen';
+  const state = {
+    leftCollapsed: localStorage.getItem(KEY_L) === 'true',
+    rightCollapsed: localStorage.getItem(KEY_R) === 'true',
+    fullscreen: localStorage.getItem(KEY_F) === 'true',
+  };
+  const apply = ()=>{
+    left.classList.toggle('is-collapsed', state.leftCollapsed);
+    right.classList.toggle('is-collapsed', state.rightCollapsed);
+    app.classList.toggle('is-fullscreen', state.fullscreen);
+  };
+  const save = ()=> {
+    localStorage.setItem(KEY_L, String(state.leftCollapsed));
+    localStorage.setItem(KEY_R, String(state.rightCollapsed));
+    localStorage.setItem(KEY_F, String(state.fullscreen));
+  };
+  apply();
+
+  // Toggle handlers (no other wiring)
+  app.addEventListener('click', (e)=>{
+    const btn = e.target.closest('.panel__toggle');
+    if (btn) {
+      const id = btn.getAttribute('data-target');
+      if (id === 'panelLeft')  { state.leftCollapsed = !state.leftCollapsed;  }
+      if (id === 'panelRight') { state.rightCollapsed = !state.rightCollapsed; }
+      apply(); save();
+    }
+  });
+  const btnFS = document.getElementById('btnFullscreen');
+  btnFS && btnFS.addEventListener('click', ()=>{ state.fullscreen = !state.fullscreen; apply(); save(); });
+
+  // DO NOT resize or replace canvas here; viewer code already handles it.
+  console.info('[layout] enhancement applied (non-destructive).');
+});

--- a/src/ui/layout.js
+++ b/src/ui/layout.js
@@ -66,11 +66,11 @@ document.addEventListener('DOMContentLoaded', () => {
     else view.parentNode.appendChild(right);
   }
 
-  // Move existing #ui (if any) into left panel body
+  // Move existing #ui (if any) into bottom bar when available
   const oldUI = $('#ui');
-  const leftBody = $('#panelLeftBody');
-  if (oldUI && leftBody && !leftBody.contains(oldUI)) {
-    leftBody.appendChild(oldUI);
+  const bottomBody = $('#panelBottomBody');
+  if (oldUI && bottomBody && !bottomBody.contains(oldUI)) {
+    bottomBody.appendChild(oldUI);
   }
 
   // State

--- a/src/ui/layout.js
+++ b/src/ui/layout.js
@@ -74,12 +74,11 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   // State
-  const KEY_L='ui.leftCollapsed', KEY_R='ui.rightCollapsed', KEY_F='ui.fullscreen';
+  const KEY_L='ui.leftCollapsed', KEY_R='ui.rightCollapsed';
   const KEY_LW='ui.leftWidth', KEY_RW='ui.rightWidth';
   const state = {
     leftCollapsed: localStorage.getItem(KEY_L) === 'true',
     rightCollapsed: localStorage.getItem(KEY_R) === 'true',
-    fullscreen: localStorage.getItem(KEY_F) === 'true',
   };
   const storedLW = parseInt(localStorage.getItem(KEY_LW),10);
   const storedRW = parseInt(localStorage.getItem(KEY_RW),10);
@@ -88,12 +87,10 @@ document.addEventListener('DOMContentLoaded', () => {
   const apply = ()=>{
     left.classList.toggle('is-collapsed', state.leftCollapsed);
     right.classList.toggle('is-collapsed', state.rightCollapsed);
-    app.classList.toggle('is-fullscreen', state.fullscreen);
   };
   const save = ()=> {
     localStorage.setItem(KEY_L, String(state.leftCollapsed));
     localStorage.setItem(KEY_R, String(state.rightCollapsed));
-    localStorage.setItem(KEY_F, String(state.fullscreen));
   };
   apply();
 
@@ -107,8 +104,6 @@ document.addEventListener('DOMContentLoaded', () => {
       apply(); save();
     }
   });
-  const btnFS = document.getElementById('btnFullscreen');
-  btnFS && btnFS.addEventListener('click', ()=>{ state.fullscreen = !state.fullscreen; apply(); save(); });
 
   // Resizable panels
   function makeResizable(panel, side) {

--- a/src/ui/panels.js
+++ b/src/ui/panels.js
@@ -1,0 +1,101 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const $  = s=>document.querySelector(s);
+  const $$ = s=>[...document.querySelectorAll(s)];
+  const app  = $('#app');
+  const top  = $('#appHeader');
+  const left = $('#panelLeft');
+  const right= $('#panelRight');
+  const bottom=$('#panelBottom');
+  const view = $('#view');
+
+  if (!app || !view) { console.warn('[panels] #app or #view missing'); return; }
+
+  // Ensure headers exist and have actions (non-destructive patch)
+  function ensureHdr(panel, title){
+    if (!panel) return;
+    let hdr = panel.querySelector('.panel__hdr');
+    if (!hdr) {
+      hdr = document.createElement('div');
+      hdr.className = 'panel__hdr';
+      hdr.innerHTML = `
+        <div class="panel__title">${title}</div>
+        <div class="panel__actions">
+          <button class="panel__collapse" data-target="${panel.id}" title="Collapse" aria-label="Collapse">▾</button>
+          <button class="panel__fs" data-target="${panel.id}" title="Fullscreen" aria-label="Fullscreen">⤢</button>
+        </div>`;
+      panel.prepend(hdr);
+      if (!panel.querySelector('.panel__body')) {
+        const body = document.createElement('div'); body.className='panel__body'; body.id=panel.id+'Body';
+        panel.appendChild(body);
+      }
+    }
+  }
+  ensureHdr(top, 'Navigation');
+  ensureHdr(left,'Controls');
+  ensureHdr(right,'Equipment');
+  ensureHdr(bottom,'Viewer Controls');
+
+  // State keys
+  const K = {
+    leftW:'ui.leftW', rightW:'ui.rightW', bottomH:'ui.bottomH', topH:'ui.topH',
+    leftCollapsed:'ui.leftCollapsed', rightCollapsed:'ui.rightCollapsed',
+    bottomCollapsed:'ui.bottomCollapsed', topCollapsed:'ui.topCollapsed',
+    fsPanel:'ui.fsPanel' // one of: 'left'|'right'|'bottom'|'top'|'view'|''
+  };
+
+  // Apply persisted sizes
+  const leftW   = parseFloat(localStorage.getItem(K.leftW)   || '') || null;
+  const rightW  = parseFloat(localStorage.getItem(K.rightW)  || '') || null;
+  const bottomH = parseFloat(localStorage.getItem(K.bottomH) || '') || null;
+  const topH    = parseFloat(localStorage.getItem(K.topH)    || '') || null;
+
+  if (leftW)  app.style.setProperty('--left-w',  leftW  + 'px');
+  if (rightW) app.style.setProperty('--right-w', rightW + 'px');
+  if (bottomH)app.style.setProperty('--bottom-h',bottomH+ 'px');
+  if (topH)   app.style.setProperty('--top-h',   topH   + 'px');
+
+  // Apply collapsed flags
+  const flag = (k)=>localStorage.getItem(k)==='true';
+  left  && left.classList.toggle('is-collapsed',   flag(K.leftCollapsed));
+  right && right.classList.toggle('is-collapsed',  flag(K.rightCollapsed));
+  bottom&& bottom.classList.toggle('is-collapsed', flag(K.bottomCollapsed));
+  top   && top.classList.toggle('is-collapsed',    flag(K.topCollapsed));
+
+  // Apply per-panel fullscreen
+  const fs = localStorage.getItem(K.fsPanel) || '';
+  if (fs) app.classList.add('fs-' + fs);
+
+  // Collapse/expand handlers
+  document.body.addEventListener('click', (e)=>{
+    const c = e.target.closest('.panel__collapse');
+    if (c){
+      const id = c.getAttribute('data-target');
+      const el = document.getElementById(id);
+      if (el){
+        const key = ({panelLeft:K.leftCollapsed,panelRight:K.rightCollapsed,panelBottom:K.bottomCollapsed,appHeader:K.topCollapsed})[id];
+        const next = !el.classList.contains('is-collapsed');
+        el.classList.toggle('is-collapsed', next);
+        if (key) localStorage.setItem(key, String(next));
+      }
+    }
+    const f = e.target.closest('.panel__fs');
+    if (f){
+      const id = f.getAttribute('data-target');
+      const map = { panelLeft:'left', panelRight:'right', panelBottom:'bottom', appHeader:'top', view:'view' };
+      const tag = map[id] || '';
+      ['fs-left','fs-right','fs-bottom','fs-top','fs-view'].forEach(cl=>app.classList.remove(cl));
+      if (tag){
+        if (localStorage.getItem(K.fsPanel) === tag) {
+          localStorage.setItem(K.fsPanel,'');
+        } else {
+          app.classList.add('fs-'+tag);
+          localStorage.setItem(K.fsPanel, tag);
+        }
+      } else {
+        localStorage.setItem(K.fsPanel,'');
+      }
+    }
+  });
+
+  console.info('[panels] universal panel controls ready');
+});

--- a/src/ui/resize-bottom.js
+++ b/src/ui/resize-bottom.js
@@ -16,7 +16,6 @@ document.addEventListener('DOMContentLoaded', () => {
 
   const KEY_H = 'ui.bottomH';
   const KEY_BC = 'ui.bottomCollapsed';
-  const KEY_FS = 'ui.fullscreen';
 
   const clamp = (v, min, max) => Math.max(min, Math.min(max, v));
 
@@ -31,7 +30,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   // Initialize height if not fullscreen/collapsed
   const initCollapsed = localStorage.getItem(KEY_BC) === 'true';
-  const initFS = localStorage.getItem(KEY_FS) === 'true';
+  const initFS = document.fullscreenElement || app.classList.contains('is-fullscreen');
   if (!initCollapsed && !initFS) {
     setBottomH(getBottomH());
   }
@@ -42,7 +41,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   function onDown(e) {
     const collapsed = bottom.classList.contains('is-collapsed') || localStorage.getItem(KEY_BC) === 'true';
-    const fs = app.classList.contains('is-fullscreen') || localStorage.getItem(KEY_FS) === 'true';
+    const fs = app.classList.contains('is-fullscreen') || document.fullscreenElement;
     if (collapsed || fs) return;
 
     dragging = true;
@@ -99,7 +98,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   const mo = new MutationObserver(() => {
     const collapsed = bottom.classList.contains('is-collapsed') || localStorage.getItem(KEY_BC) === 'true';
-    const fs = app.classList.contains('is-fullscreen') || localStorage.getItem(KEY_FS) === 'true';
+    const fs = app.classList.contains('is-fullscreen') || document.fullscreenElement;
     if (collapsed || fs) {
       // seam hidden
     } else {

--- a/src/ui/resize-bottom.js
+++ b/src/ui/resize-bottom.js
@@ -1,0 +1,115 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const $ = s => document.querySelector(s);
+  const app = $('#app');
+  const view = $('#view');
+  const bottom = $('#panelBottom');
+  if (!app || !view || !bottom) { console.warn('[resize-bottom] required nodes missing; skipping.'); return; }
+
+  // Create an overlay host that owns the ::after seam (non-destructive)
+  let seamHost = document.getElementById('splitterBottomHost');
+  if (!seamHost) {
+    seamHost = document.createElement('div');
+    seamHost.id = 'splitterBottomHost';
+    seamHost.className = 'splitter--bottom';
+    app.appendChild(seamHost);
+  }
+
+  const KEY_H = 'ui.bottomH';
+  const KEY_BC = 'ui.bottomCollapsed';
+  const KEY_FS = 'ui.fullscreen';
+
+  const clamp = (v, min, max) => Math.max(min, Math.min(max, v));
+
+  function getBottomH() {
+    const saved = parseFloat(localStorage.getItem(KEY_H));
+    return Number.isFinite(saved) ? saved : 120;
+  }
+  function setBottomH(px) {
+    app.style.setProperty('--bottom-h', `${px}px`);
+    localStorage.setItem(KEY_H, String(px));
+  }
+
+  // Initialize height if not fullscreen/collapsed
+  const initCollapsed = localStorage.getItem(KEY_BC) === 'true';
+  const initFS = localStorage.getItem(KEY_FS) === 'true';
+  if (!initCollapsed && !initFS) {
+    setBottomH(getBottomH());
+  }
+
+  let dragging = false;
+  let startY = 0;
+  let startH = 0;
+
+  function onDown(e) {
+    const collapsed = bottom.classList.contains('is-collapsed') || localStorage.getItem(KEY_BC) === 'true';
+    const fs = app.classList.contains('is-fullscreen') || localStorage.getItem(KEY_FS) === 'true';
+    if (collapsed || fs) return;
+
+    dragging = true;
+    startY = (e.touches ? e.touches[0].clientY : e.clientY);
+    startH = getBottomH();
+    document.body.style.userSelect = 'none';
+    window.addEventListener('mousemove', onMove);
+    window.addEventListener('touchmove', onMove, {passive:false});
+    window.addEventListener('mouseup', onUp, {once:true});
+    window.addEventListener('touchend', onUp, {once:true});
+  }
+
+  function onMove(e) {
+    if (!dragging) return;
+    const y = (e.touches ? e.touches[0].clientY : e.clientY);
+    const dy = startY - y;
+    const next = clamp(startH + dy, 56, Math.min(window.innerHeight * 0.6, 400));
+    setBottomH(next);
+    e.preventDefault?.();
+  }
+
+  function onUp() {
+    dragging = false;
+    document.body.style.userSelect = '';
+    window.removeEventListener('mousemove', onMove);
+    window.removeEventListener('touchmove', onMove);
+  }
+
+  // Attach pointer handlers to a real element placed at the seam
+  let grab = document.getElementById('bottomGrabber');
+  if (!grab) {
+    grab = document.createElement('div');
+    grab.id = 'bottomGrabber';
+    grab.style.position = 'absolute';
+    grab.style.left = 0; grab.style.right = 0;
+    grab.style.height = '6px';
+    grab.style.cursor = 'ns-resize';
+    grab.style.zIndex = 6;
+    seamHost.appendChild(grab);
+  }
+
+  function syncGrabber() {
+    const h = getBottomH();
+    grab.style.bottom = `${h}px`;
+  }
+
+  const ro = new ResizeObserver(syncGrabber);
+  ro.observe(app);
+  window.addEventListener('resize', syncGrabber);
+  syncGrabber();
+
+  grab.addEventListener('mousedown', onDown);
+  grab.addEventListener('touchstart', onDown, {passive:true});
+
+  const mo = new MutationObserver(() => {
+    const collapsed = bottom.classList.contains('is-collapsed') || localStorage.getItem(KEY_BC) === 'true';
+    const fs = app.classList.contains('is-fullscreen') || localStorage.getItem(KEY_FS) === 'true';
+    if (collapsed || fs) {
+      // seam hidden
+    } else {
+      setBottomH(getBottomH());
+      syncGrabber();
+    }
+  });
+  mo.observe(app, { attributes:true, attributeFilter:['class'] });
+  mo.observe(bottom, { attributes:true, attributeFilter:['class'] });
+
+  console.info('[resize-bottom] enabled: drag the seam between viewer and bottom panel to resize.');
+});
+

--- a/src/ui/resize-panels.js
+++ b/src/ui/resize-panels.js
@@ -1,0 +1,100 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const $  = s=>document.querySelector(s);
+  const app  = $('#app');
+  const top  = $('#appHeader');
+  const left = $('#panelLeft');
+  const right= $('#panelRight');
+  const bottom=$('#panelBottom');
+  const view = $('#view');
+  if (!app || !view) { console.warn('[resize-panels] #app or #view missing'); return; }
+
+  // Create splitter elements (non-destructive)
+  function ensureSplitter(id, cls, parent){
+    let el = document.getElementById(id);
+    if (!el){
+      el = document.createElement('div');
+      el.id = id; el.className = cls;
+      parent.appendChild(el);
+    }
+    return el;
+  }
+  // Splitters are absolutely positioned in #view’s stacking context so they sit on seams
+  const sLeft   = ensureSplitter('splitLeft',   'splitter-v', view);
+  const sRight  = ensureSplitter('splitRight',  'splitter-v', view);
+  const sTop    = ensureSplitter('splitTop',    'splitter-h', view);
+  const sBottom = ensureSplitter('splitBottom', 'splitter-h', view);
+
+  const K = { leftW:'ui.leftW', rightW:'ui.rightW', bottomH:'ui.bottomH', topH:'ui.topH', fsPanel:'ui.fsPanel' };
+
+  function isFS(){ return !!localStorage.getItem(K.fsPanel); }
+
+  let dragging = null; // 'left'|'right'|'top'|'bottom'
+  let startX=0, startY=0, startLW=0, startRW=0, startBH=0, startTH=0;
+
+  const onDown = (which)=>(e)=>{
+    if (isFS()) return; // disable in per-panel fullscreen
+    document.body.classList.add('is-dragging');
+    dragging = which;
+    const evt = e.touches ? e.touches[0] : e;
+    startX = evt.clientX; startY = evt.clientY;
+    const cs = getComputedStyle(app);
+    startLW = parseFloat(cs.getPropertyValue('--left-w'))  || 280;
+    startRW = parseFloat(cs.getPropertyValue('--right-w')) || 320;
+    startBH = parseFloat(cs.getPropertyValue('--bottom-h'))|| 120;
+    startTH = parseFloat(cs.getPropertyValue('--top-h'))   || 56;
+    window.addEventListener('mousemove', onMove);
+    window.addEventListener('touchmove', onMove, {passive:false});
+    window.addEventListener('mouseup', onUp, {once:true});
+    window.addEventListener('touchend', onUp, {once:true});
+  };
+
+  function onMove(e){
+    if (!dragging) return;
+    const evt = e.touches ? e.touches[0] : e;
+    const dx = evt.clientX - startX;
+    const dy = evt.clientY - startY;
+
+    // clamp helpers
+    const clamp = (v,min,max)=>Math.max(min, Math.min(max, v));
+
+    if (dragging==='left'){
+      const next = clamp(startLW + dx, 180, Math.min(window.innerWidth*0.5, 600));
+      app.style.setProperty('--left-w', next+'px');
+      localStorage.setItem(K.leftW, String(next));
+    }
+    if (dragging==='right'){
+      const next = clamp(startRW - dx, 180, Math.min(window.innerWidth*0.5, 600));
+      app.style.setProperty('--right-w', next+'px');
+      localStorage.setItem(K.rightW, String(next));
+    }
+    if (dragging==='bottom'){
+      const next = clamp(startBH - dy, 56, Math.min(window.innerHeight*0.6, 500));
+      app.style.setProperty('--bottom-h', next+'px');
+      localStorage.setItem(K.bottomH, String(next));
+    }
+    if (dragging==='top'){
+      const next = clamp(startTH + dy, 44, Math.min(window.innerHeight*0.4, 220));
+      app.style.setProperty('--top-h', next+'px');
+      localStorage.setItem(K.topH, String(next));
+    }
+    e.preventDefault?.();
+  }
+
+  function onUp(){
+    dragging = null;
+    document.body.classList.remove('is-dragging');
+    window.removeEventListener('mousemove', onMove);
+    window.removeEventListener('touchmove', onMove);
+  }
+
+  sLeft.addEventListener('mousedown', onDown('left'));
+  sRight.addEventListener('mousedown', onDown('right'));
+  sBottom.addEventListener('mousedown', onDown('bottom'));
+  sTop.addEventListener('mousedown', onDown('top'));
+  sLeft.addEventListener('touchstart', onDown('left'), {passive:true});
+  sRight.addEventListener('touchstart', onDown('right'), {passive:true});
+  sBottom.addEventListener('touchstart', onDown('bottom'), {passive:true});
+  sTop.addEventListener('touchstart', onDown('top'), {passive:true});
+
+  console.info('[resize-panels] splitters ready (left/right/top/bottom).');
+});

--- a/src/ui/toolbar-objects.js
+++ b/src/ui/toolbar-objects.js
@@ -1,0 +1,39 @@
+import { initObjectControls } from '../three/controls/objectControls.js';
+import { dispatch } from '../state/store.js';
+
+let api = null;
+
+export function mountObjectToolbar(ctx){
+  api = initObjectControls(ctx);
+
+  const $ = id => document.getElementById(id);
+
+  $('#toolSelect')?.addEventListener('click', ()=>{
+    api.setModeSelect();
+    api.setSnapEnabled($('#chkSnap')?.checked);
+  });
+  $('#toolTranslate')?.addEventListener('click', ()=> api.setModeTranslate());
+  $('#toolRotate')?.addEventListener('click', ()=> api.setModeRotate());
+  $('#btnDuplicate')?.addEventListener('click', ()=> api.duplicateSelected());
+  $('#btnDeleteObj')?.addEventListener('click', ()=> api.deleteSelected());
+  $('#btnUndoObj')?.addEventListener('click', ()=> dispatch({type:'Undo'}));
+  $('#btnRedoObj')?.addEventListener('click', ()=> dispatch({type:'Redo'}));
+
+  $('#chkSnap')?.addEventListener('change', (e)=> api.setSnapEnabled(e.target.checked));
+  $('#snapSize')?.addEventListener('change', (e)=> api.setSnapSize(parseFloat(e.target.value)));
+
+  // Keyboard shortcuts
+  window.addEventListener('keydown', (e)=>{
+    const mod = e.ctrlKey || e.metaKey;
+    if (e.key==='w' || e.key==='W'){ api.setModeTranslate(); }
+    if (e.key==='e' || e.key==='E'){ api.setModeRotate(); }
+    if (mod && (e.key==='z' || e.key==='Z')){ dispatch({type:'Undo'}); e.preventDefault(); }
+    if (mod && (e.key==='y' || e.key==='Y')){ dispatch({type:'Redo'}); e.preventDefault(); }
+    if (mod && (e.key==='d' || e.key==='D')){ api.duplicateSelected(); e.preventDefault(); }
+    if (e.key==='Delete' || e.key==='Backspace'){ api.deleteSelected(); e.preventDefault(); }
+    if (mod && (e.key==='g' || e.key==='G')){
+      const chk = document.getElementById('chkSnap'); if (chk){ chk.checked = !chk.checked; chk.dispatchEvent(new Event('change')); }
+      e.preventDefault();
+    }
+  });
+}

--- a/src/viewer/SceneGraph.ts
+++ b/src/viewer/SceneGraph.ts
@@ -1,6 +1,7 @@
 import * as THREE from 'three';
 import { projectStore } from '../state/projectStore';
 import { createSpeakerMesh, SpeakerMesh } from '../three/objects/SpeakerMesh';
+import { registerSelectable, unregisterSelectable } from '../three/controls/objectControls.js';
 
 export class SceneGraph {
   private scene: THREE.Scene;
@@ -19,6 +20,7 @@ export class SceneGraph {
     // remove missing
     for (const [id, mesh] of this.meshes) {
       if (!ids.has(id)) {
+        unregisterSelectable(mesh);
         this.scene.remove(mesh);
         this.meshes.delete(id);
       }
@@ -29,8 +31,10 @@ export class SceneGraph {
       let mesh = this.meshes.get(sp.id);
       if (!mesh) {
         mesh = createSpeakerMesh(sp);
+        mesh.userData = { id: sp.id, kind: 'speaker' };
         this.meshes.set(sp.id, mesh);
         this.scene.add(mesh);
+        registerSelectable(mesh);
       } else {
         mesh.position.set(sp.pos.x, sp.pos.y, sp.pos.z);
         mesh.rotation.y = sp.rotY;


### PR DESCRIPTION
## Summary
- add dark-theme grid layout with header and collapsible side panels
- provide layout script handling panel toggles, fullscreen, and state
- update index to wire in layout assets and wrap existing UI

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: 403 Forbidden retrieving packages)*

------
https://chatgpt.com/codex/tasks/task_e_68afc24eb2dc8331b3857492cb92704f