### PR TITLE
feat(phase-2): implement First Reflections overlay + equipment DB expansion with validation

### DIFF
--- a/data/amps_starter.json
+++ b/data/amps_starter.json
@@ -1,0 +1,4 @@
+[
+  {"id":"ampstarter1","brand":"AmpCo","model":"Amp100","specs":{"power_w_8ohm_all":100}},
+  {"id":"ampstarter2","brand":"AmpCo","model":"Amp200"}
+]

--- a/data/speakers_starter.csv
+++ b/data/speakers_starter.csv
@@ -1,0 +1,3 @@
+id,brand,model,price
+spstarter1,StarterCo,ModelS1,199
+spstarter2,StarterCo,ModelS2,

--- a/src/agents/equipment.agent.ts
+++ b/src/agents/equipment.agent.ts
@@ -2,6 +2,7 @@ import { AnyEquipment } from "../types/equipment";
 import { safeParse } from "../lib/validate";
 import { log } from "../lib/log";
 import { AnyEquipment as AnyEquipmentSchema } from "../types/equipment";
+import Papa from "papaparse";
 
 export type EquipmentItem = {
   id: string;
@@ -15,6 +16,7 @@ export type EquipmentItem = {
   spinVerified?: boolean;
   specs?: Record<string, string | number | null>;
   provenance?: { source: string; url?: string; date?: string };
+  warnings?: string[];
 };
 
 export type EquipmentManifest = {
@@ -60,6 +62,10 @@ function baseValidate(obj: any, id: string, kind: "speaker" | "amp"): EquipmentI
     });
     if (Object.keys(specs).length) item.specs = specs;
   }
+  const warnings: string[] = [];
+  if (item.price == null) warnings.push("price missing");
+  if (!item.spinVerified) warnings.push("data unverified");
+  if (warnings.length) item.warnings = warnings;
   return item;
 }
 
@@ -94,6 +100,34 @@ export async function fetchEquipment(): Promise<{ speakers: EquipmentItem[]; amp
     const id = path.split("/").pop()?.replace(/\.json$/i, "") || "";
     const item = validateAmp(obj, id);
     if (item) amps.push(item); else hadErrors = true;
+  }
+
+  try {
+    const res = await fetch("/data/speakers_starter.csv");
+    if (res.ok) {
+      const text = await res.text();
+      const parsed = Papa.parse(text, { header: true });
+      parsed.data.forEach((row: any, idx: number) => {
+        const id = row.id || `starter_sp_${idx}`;
+        const item = validateSpeaker(row, id);
+        if (item) speakers.push(item); else hadErrors = true;
+      });
+    }
+  } catch {
+    /* ignore */
+  }
+
+  try {
+    const arr = await loadJSON("/data/amps_starter.json");
+    if (Array.isArray(arr)) {
+      arr.forEach((row: any, idx: number) => {
+        const id = row.id || `starter_amp_${idx}`;
+        const item = validateAmp(row, id);
+        if (item) amps.push(item); else hadErrors = true;
+      });
+    }
+  } catch {
+    /* ignore */
   }
 
   const order = { A: 0, B: 1, C: 2 } as Record<string, number>;

--- a/src/main.js
+++ b/src/main.js
@@ -783,7 +783,15 @@ function recomputeReflections() {
     reflections.setHits([]);
     return;
   }
-  reflectionHits = firstOrder({ room: roomDims, speakers: state.speakers, mlp });
+  const hits = firstOrder({ room: roomDims, speakers: state.speakers, mlp });
+  reflectionHits = hits.map(h => {
+    const sp = state.speakers.find(s => s.id === h.speakerId);
+    return {
+      ...h,
+      speaker: sp ? [sp.pos.x, sp.pos.y, sp.pos.z] : undefined,
+      listener: [mlp.x, mlp.y, mlp.z]
+    };
+  });
   reflections.setHits(reflectionHits);
 }
 
@@ -795,6 +803,16 @@ reflectionsToggle?.addEventListener('change', () => {
 window.addEventListener('placement:changed', recomputeReflections);
 window.addEventListener('pointerup', () => {
   window.dispatchEvent(new CustomEvent('placement:changed'));
+});
+
+window.addEventListener('project:loaded', e => {
+  const data = e.detail || {};
+  if (Array.isArray(data.reflections)) {
+    reflectionHits = data.reflections;
+    reflectionsToggle.checked = data.reflections.length > 0;
+    reflections.setEnabled(reflectionsToggle.checked);
+    reflections.setHits(data.reflections);
+  }
 });
 
 const micGroup = new THREE.Group();

--- a/src/panels/EquipmentPanel.js
+++ b/src/panels/EquipmentPanel.js
@@ -118,7 +118,11 @@ export function mountEquipmentPanel() {
       badge.setAttribute('title', `CEA-2034 data imported; confidence: ${spin.confidence_0_1.toFixed(2)}; source: ${spin.source || 'N/A'}`);
       stats.querySelector('.speaker-name')?.appendChild(badge);
     }
-    warn.textContent = head < 0 ? '⚠️ Underpowered for target SPL at this distance.' : '';
+    const warns = [];
+    if (head < 0) warns.push('⚠️ Underpowered for target SPL at this distance.');
+    if (spData?.warnings) warns.push(...spData.warnings);
+    if (ampData?.warnings) warns.push(...ampData.warnings);
+    warn.textContent = warns.join(' ');
   }
 
   function onChange() {

--- a/src/render/ReflectionsLayer.js
+++ b/src/render/ReflectionsLayer.js
@@ -29,29 +29,50 @@ export class ReflectionsLayer {
     let i = 0;
     const radius = 0.12;
     hits.forEach(h => {
-      let mesh = this.pool[i];
-      if (!mesh) {
+      let pair = this.pool[i];
+      if (!pair) {
         const geo = new THREE.SphereGeometry(radius, 12, 12);
         const mat = new THREE.MeshBasicMaterial();
-        mesh = new THREE.Mesh(geo, mat);
-        this.pool[i] = mesh;
+        const sphere = new THREE.Mesh(geo, mat);
+        const lineMat = new THREE.LineBasicMaterial();
+        const lineGeo = new THREE.BufferGeometry();
+        const line = new THREE.Line(lineGeo, lineMat);
+        pair = { sphere, line };
+        this.pool[i] = pair;
       }
-      mesh.material.color.setHex(this._colorFor(h.surface));
-      mesh.position.set(h.point[0], h.point[1], h.point[2]);
-      if (!mesh.parent) this.group.add(mesh);
+      const color = this._colorFor(h.surface);
+      pair.sphere.material.color.setHex(color);
+      pair.sphere.position.set(h.point[0], h.point[1], h.point[2]);
+      if (!pair.sphere.parent) this.group.add(pair.sphere);
+
+      if (h.speaker && h.listener) {
+        const pts = [
+          new THREE.Vector3(h.speaker[0], h.speaker[1], h.speaker[2]),
+          new THREE.Vector3(h.point[0], h.point[1], h.point[2]),
+          new THREE.Vector3(h.listener[0], h.listener[1], h.listener[2])
+        ];
+        pair.line.material.color.setHex(color);
+        pair.line.geometry.setFromPoints(pts);
+        if (!pair.line.parent) this.group.add(pair.line);
+      } else if (pair.line.parent) {
+        pair.line.parent.remove(pair.line);
+      }
       i++;
     });
-    // remove unused meshes
+    // remove unused items
     for (let j = i; j < this.pool.length; j++) {
-      const m = this.pool[j];
-      if (m.parent) m.parent.remove(m);
+      const { sphere, line } = this.pool[j];
+      if (sphere.parent) sphere.parent.remove(sphere);
+      if (line.parent) line.parent.remove(line);
     }
   }
 
   dispose() {
-    this.pool.forEach(m => {
-      m.geometry.dispose();
-      m.material.dispose();
+    this.pool.forEach(p => {
+      p.sphere.geometry.dispose();
+      p.sphere.material.dispose();
+      p.line.geometry.dispose();
+      p.line.material.dispose();
     });
     this.scene.remove(this.group);
   }

--- a/tests/acoustics/ism.test.js
+++ b/tests/acoustics/ism.test.js
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest';
+import { firstOrder } from '../../src/acoustics/ism.js';
+
+describe('firstOrder reflections', () => {
+  it('returns empty when speakers missing', () => {
+    const res = firstOrder({ room: { L:5, W:4, H:3 }, speakers: [], mlp: { x:0, y:1, z:0 } });
+    expect(res).toEqual([]);
+  });
+
+  it('computes hits for simple case', () => {
+    const room = { L:5, W:4, H:3 };
+    const speakers = [{ id:'s1', pos:{ x:1, y:1, z:1 } }];
+    const mlp = { x:2, y:1, z:2 };
+    const res = firstOrder({ room, speakers, mlp });
+    expect(res.length).toBeGreaterThan(0);
+    expect(res[0]).toHaveProperty('surface');
+  });
+});

--- a/tests/agents/equipment.agent.test.ts
+++ b/tests/agents/equipment.agent.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from "vitest";
-import { normalizeEquipment } from "../../src/agents/equipment.agent";
+import { describe, it, expect, vi } from "vitest";
+import { normalizeEquipment, fetchEquipment } from "../../src/agents/equipment.agent";
 
 describe("equipment agent", () => {
   it("normalizes valid rows", () => {
@@ -10,5 +10,25 @@ describe("equipment agent", () => {
     const items = normalizeEquipment(rows);
     expect(items).toHaveLength(1);
     expect(items[0].id).toBe("1");
+  });
+
+  it("fetchEquipment skips invalid entries", async () => {
+    const manifest = { speakers: ["good.json", "bad.json"], amps: [] };
+    const files: Record<string, any> = {
+      "/data/manifest.json": manifest,
+      "/good.json": { brand: "B", model: "M" },
+      "/bad.json": { foo: "bar" }
+    };
+    const orig = global.fetch;
+    global.fetch = vi.fn((path: string) => {
+      const url = String(path);
+      const data = files[url];
+      if (!data) return Promise.resolve({ ok: false } as any);
+      return Promise.resolve({ ok: true, json: () => Promise.resolve(data) } as any);
+    });
+    const res = await fetchEquipment();
+    expect(res.speakers).toHaveLength(1);
+    expect(res.errors).toBe(true);
+    global.fetch = orig;
   });
 });


### PR DESCRIPTION
## Summary
- draw first-reflection paths with lines between speaker, hit, and listener points
- ingest starter speaker CSV and amp JSON files with validation and warning flags
- expose equipment warnings in UI and add regression tests for reflections and data loading

## Testing
- `npm test` *(fails: sh: 1: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b4576b4a708331856ccebb42d7c5f9